### PR TITLE
Fix styles for resource cards

### DIFF
--- a/desk.css
+++ b/desk.css
@@ -901,6 +901,16 @@ section {
   flex-direction: column;
   justify-content: space-between;
   transition: transform 0.2s ease;
+  text-decoration: none;
+  color: inherit;
+}
+
+.resource-card h3 {
+  color: #457B9D;
+}
+
+.resource-card p {
+  color: #2E4057;
 }
 
 .resource-card:hover {

--- a/mobile.css
+++ b/mobile.css
@@ -258,6 +258,28 @@
 
 }
 
+.resource-card {
+  background: #ffffff;
+  border-radius: 10px;
+  box-shadow: 0 0 10px rgba(0,0,0,0.05);
+  padding: 20px;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  transition: transform 0.2s ease;
+  text-decoration: none;
+  color: inherit;
+}
+
+.resource-card h3 {
+  color: #457B9D;
+}
+
+.resource-card p {
+  color: #2E4057;
+}
+
 
 
 /* Overlay: inicialmente oculto */


### PR DESCRIPTION
## Summary
- remove hyperlink styling from resource cards
- ensure text colors match site design

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a12d71ca88322a569d5466f38006b