### PR TITLE
Add educacion.css with accordion styling adjustments

### DIFF
--- a/educacion.css
+++ b/educacion.css
@@ -1,0 +1,26 @@
+/* Placeholder existing rules for educacion.css */
+
+.accordion-title {
+  /* ... reglas actuales ... */
+  background: var(--azul-profundo);
+  padding: 15px;
+  /* etc. */
+}
+
+.accordion-title::after {
+  content: "+";
+  color: #ff6b35;
+  /* etc. */
+}
+
+
+/* Ajustes solicitados */
+.accordion-title {
+  color: #ffffff;
+  font-size: clamp(0.7rem, 0.9vw, 0.8rem);
+}
+
+.accordion-title::after {
+  color: #ffffff;
+}
+


### PR DESCRIPTION
## Summary
- add `educacion.css` with initial rules for `.accordion-title`
- append requested changes making the title and symbol white and reducing font size

No tests found in repo.

------
https://chatgpt.com/codex/tasks/task_e_684a3243bec08322b0e6864ce2075059