### PR TITLE
Render bank and finance notes as markdown

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -30,7 +30,7 @@ collections:
             widget: "list"
             fields:
               - { label: "Título", name: "title", widget: "string" }
-              - { label: "Contenido", name: "content", widget: "text" }
+              - { label: "Contenido", name: "content", widget: "markdown" }
 
   - name: "finanzas"
     label: "Aprende de Finanzas"
@@ -44,4 +44,4 @@ collections:
             widget: "list"
             fields:
               - { label: "Título", name: "title", widget: "string" }
-              - { label: "Contenido", name: "content", widget: "text" }
+              - { label: "Contenido", name: "content", widget: "markdown" }

--- a/educacion.css
+++ b/educacion.css
@@ -24,3 +24,7 @@
   color: #ffffff;
 }
 
+.accordion-content p {
+  margin: 0 0 1em;
+}
+

--- a/educacion.html
+++ b/educacion.html
@@ -178,6 +178,7 @@
   <div class="overlay"></div>
 
 
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="educacion.js"></script>
   <script src="header.js"></script>
 </body>

--- a/educacion.js
+++ b/educacion.js
@@ -41,10 +41,11 @@ document.addEventListener('DOMContentLoaded', () => {
       .then(data => {
         const items = data.entries;
         container.innerHTML = items.map((it, idx) => {
+          const htmlContent = marked.parse(it.content);
           return `\
             <div class="accordion-item">\
               <button class="accordion-title" data-index="${idx}">${it.title}</button>\
-              <div class="accordion-content">${it.content}</div>\
+              <div class="accordion-content">${htmlContent}</div>\
             </div>`;
         }).join('');
         setupAccordion();


### PR DESCRIPTION
## Summary
- enable markdown widget in Netlify CMS for finance/bank entries
- load Marked in `educacion.html`
- parse markdown in `educacion.js`
- style accordion paragraph spacing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b65a777c883228d3055409d9aca38