### PR TITLE
Automatically load blog posts from repo

### DIFF
--- a/blog/blog.js
+++ b/blog/blog.js
@@ -17,21 +17,29 @@ function parseFrontMatter(md) {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
-  fetch('posts.json')
+  const repo = 'nmoroso/nicolasmoroso-paginaweb';
+  const branch = 'main';
+  const apiUrl = `https://api.github.com/repos/${repo}/contents/blog?ref=${branch}`;
+
+  fetch(apiUrl)
     .then(r => r.json())
-    .then(posts => {
+    .then(files => files.filter(f => f.name.endsWith('.md')))
+    .then(files => Promise.all(files.map(f => fetch(f.download_url).then(res => res.text()))))
+    .then(markdowns => {
       const container = document.getElementById('blog-posts');
-      posts.forEach(post => {
-        fetch(post.file)
-          .then(res => res.text())
-          .then(md => {
-            const { meta, content } = parseFrontMatter(md);
-            const article = document.createElement('article');
-            const html = marked.parse(content);
-            article.innerHTML = `<h2>${meta.title || ''}</h2>\n<div class="date">${meta.date || ''}</div>\n${html}`;
-            container.appendChild(article);
-          })
-          .catch(err => console.error(err));
+      const posts = markdowns.map(md => parseFrontMatter(md));
+
+      posts.sort((a, b) => {
+        const dateA = new Date(a.meta.date || 0);
+        const dateB = new Date(b.meta.date || 0);
+        return dateB - dateA;
+      });
+
+      posts.forEach(({ meta, content }) => {
+        const article = document.createElement('article');
+        const html = marked.parse(content);
+        article.innerHTML = `<h2>${meta.title || ''}</h2>\n<div class="date">${meta.date || ''}</div>\n${html}`;
+        container.appendChild(article);
       });
     })
     .catch(err => console.error('Error cargando posts', err));


### PR DESCRIPTION
## Summary
- fetch blog posts directly from GitHub instead of relying on `posts.json`
- sort posts by date so new posts appear first

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684cbe564ab88322a1bc86b837c56f5c