### PR TITLE
Fix blog layout and image support

### DIFF
--- a/blog/blog.js
+++ b/blog/blog.js
@@ -49,8 +49,10 @@ document.addEventListener('DOMContentLoaded', function() {
         wrapper.className = 'blog-post-wrapper';
 
         wrapper.innerHTML = `
-          <h1 class="blog-title">${meta.title || ''}</h1>
-          <p class="blog-date">${meta.date || ''}</p>
+          <div class="blog-header">
+            <h1 class="blog-title">${meta.title || ''}</h1>
+            <p class="blog-date">${meta.date || ''}</p>
+          </div>
           ${imageUrl ? `<div class="blog-image-wrapper"><img src="${imageUrl}" alt="Imagen del post" class="blog-image"></div>` : ''}
           <div class="blog-content">${html}</div>
         `;

--- a/blog/index.html
+++ b/blog/index.html
@@ -11,25 +11,29 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
   <style>
   .blog-post-wrapper {
-    max-width: 100%;
-    padding: 2rem 0;
     display: flex;
     flex-direction: column;
     align-items: center;
+    padding: 2rem 0;
+    margin: 0 auto;
+    width: 50%;
+    max-width: 900px;
+  }
+
+  .blog-header {
+    text-align: center;
+    margin-bottom: 1.5rem;
   }
 
   .blog-title {
-    font-size: 2.2rem;
-    font-weight: 700;
-    text-align: center;
+    font-size: 2rem;
+    font-weight: bold;
     margin-bottom: 0.5rem;
   }
 
   .blog-date {
     font-size: 0.95rem;
     color: #666;
-    text-align: center;
-    margin-bottom: 1.5rem;
   }
 
   .blog-image-wrapper {
@@ -45,15 +49,13 @@
   }
 
   .blog-content {
-    width: 50%;
-    max-width: 900px;
     text-align: left;
     font-size: 1rem;
     line-height: 1.8;
   }
 
   @media (max-width: 1024px) {
-    .blog-content {
+    .blog-post-wrapper {
       width: 80%;
     }
     .blog-image-wrapper {
@@ -118,7 +120,6 @@
   </header>
 
   <main class="container" style="padding: 120px 20px 60px 20px;">
-    <h1 style="text-align:center;">Blog</h1>
     <div id="blog-posts"></div>
   </main>
 


### PR DESCRIPTION
## Summary
- style blog posts with flexible wrapper and margins
- remove hardcoded `Blog` title
- keep titles and dates inside a header block

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684cc9da6fb8832297290d2f9a7eab78