### PR TITLE
Update accordion styling and rendering

### DIFF
--- a/educacion.css
+++ b/educacion.css
@@ -1,30 +1,79 @@
-/* Placeholder existing rules for educacion.css */
-
-.accordion-title {
-  /* ... reglas actuales ... */
-  background: var(--azul-profundo);
-  padding: 15px;
-  /* etc. */
+/* Pestañas */
+.education-tabs button {
+  padding: 10px 20px;
+  border-radius: 6px;
+  background: #457B9D;
+  color: white;
+  font-weight: 600;
+  transition: background 0.2s;
+}
+.education-tabs button:hover,
+.education-tabs button.active {
+  background: #ff6b35;
 }
 
+/* Tarjeta acordeón */
+.accordion-item {
+  background: white;
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+  margin-bottom: 24px;
+  transition: transform 0.2s;
+}
+.accordion-item:hover {
+  transform: translateY(-3px);
+}
+.accordion-title {
+  border: none;
+  background: none;
+  width: 100%;
+  padding: 0;
+  cursor: pointer;
+}
+.accordion-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 14px 18px;
+  background: #457B9D;
+  color: white;
+  border-radius: 10px 10px 0 0;
+}
+.accordion-img {
+  width: 48px;
+  height: 48px;
+  object-fit: cover;
+  border-radius: 8px;
+}
+.accordion-title-text strong {
+  font-size: clamp(0.9rem,1vw,1.1rem);
+  color: white;
+}
+.accordion-tag {
+  font-size: 0.65rem;
+  background: #ff6b35;
+  color: white;
+  padding: 3px 10px;
+  border-radius: 4px;
+  margin-top: 4px;
+}
 .accordion-title::after {
   content: "+";
-  color: #ff6b35;
-  /* etc. */
+  margin-left: auto;
+  transition: transform 0.2s;
 }
-
-
-/* Ajustes solicitados */
-.accordion-title {
-  color: #ffffff;
-  font-size: clamp(0.7rem, 0.9vw, 0.8rem);
+.accordion-item.active .accordion-title::after {
+  content: "-";
+  transform: rotate(180deg);
 }
-
-.accordion-title::after {
-  color: #ffffff;
+.accordion-content {
+  display: none;
+  padding: 16px 20px;
+  background: #fafafa;
+  border-top: 1px solid #ececec;
+  color: #2E4057;
 }
-
-.accordion-content p {
-  margin: 0 0 1em;
+.accordion-item.active .accordion-content {
+  display: block;
 }
 

--- a/educacion.js
+++ b/educacion.js
@@ -20,10 +20,11 @@ document.addEventListener('DOMContentLoaded', () => {
       const bancos = data.filter(entry => entry.Sección === "Aprende de Bancos");
 
       const mapped = bancos.map(it => ({
-        title: it.Name,
-        content: it.Contenido
+        Name: it.Name,
+        content: it.Contenido,
+        Imagen: it.Imagen,
+        Subcategoría: it.Subcategoría
       }));
-
 
       renderEntries(mapped);
     });
@@ -36,8 +37,10 @@ document.addEventListener('DOMContentLoaded', () => {
       const finanzas = data.filter(entry => entry.Sección === "Aprende de Finanzas");
 
       const mapped = finanzas.map(it => ({
-        title: it.Name,
-        content: it.Contenido
+        Name: it.Name,
+        content: it.Contenido,
+        Imagen: it.Imagen,
+        Subcategoría: it.Subcategoría
       }));
 
       renderEntries(mapped);
@@ -109,25 +112,24 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
 function renderEntries(items) {
+  const container = document.getElementById('education-content');
   container.innerHTML = items.map((it, i) => {
-    const htmlContent = marked.parse(it.content || '');
-    const image = it.Imagen ? `<img src="${it.Imagen}" alt="${it.title}" class="accordion-img">` : '';
+    const html = marked.parse(it.content || '');
+    const img = it.Imagen ? `<img src="${it.Imagen}" alt="" class="accordion-img">` : '';
     const tag = it.Subcategoría ? `<div class="accordion-tag">${it.Subcategoría}</div>` : '';
-
     return `
       <div class="accordion-item">
         <button class="accordion-title" data-index="${i}">
           <div class="accordion-header">
-            ${image}
+            ${img}
             <div class="accordion-title-text">
-              <strong>${it.title}</strong>
+              <strong>${it.Name}</strong>
               ${tag}
             </div>
           </div>
         </button>
-        <div class="accordion-content">${htmlContent}</div>
-      </div>
-    `;
+        <div class="accordion-content">${html}</div>
+      </div>`;
   }).join('');
   setupAccordion();
 }


### PR DESCRIPTION
## Summary
- fetch finance and bank data in original loaders but keep Notion proxy URLs
- render entries using new markup from Notion fields
- style Education accordion and tabs to match site cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684edf4395e08322badfd4ae09140d01