### PR TITLE
Adjust Terapia Financiera section style

### DIFF
--- a/desk.css
+++ b/desk.css
@@ -1373,9 +1373,11 @@ section {
 }
 #terapia-financiera {
   padding: 4rem 0;
+  margin-left: 0;
+  margin-right: 0;
   border-radius: 20px;
   overflow: hidden;
-  background-color: #f9f9f9;
+  background-color: transparent;
   color: #333;
   font-family: 'Inter', sans-serif;
 }

--- a/mobile.css
+++ b/mobile.css
@@ -221,6 +221,12 @@
     margin-right: 3.5vw;
   }
 
+  #terapia-financiera {
+    margin-left: 0;
+    margin-right: 0;
+    background-color: transparent;
+  }
+
 
   .about-section {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- remove grey background from the Terapia Financiera section
- override margins for that section on desktop and mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865df56e65c832292a236c1ea139d23