### PR TITLE
Adjust Terapia Financiera layout on mobile

### DIFF
--- a/mobile.css
+++ b/mobile.css
@@ -228,6 +228,16 @@
     background-color: transparent;
   }
 
+  /* Ajustes para la sección Terapia Financiera en móviles */
+  #terapia-financiera .tf-grid {
+    grid-template-columns: 1fr;
+  }
+
+  #terapia-financiera .tf-sd,
+  #terapia-financiera .tf-ii {
+    display: none;
+  }
+
 
   .about-section {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- tweak responsive layout for `Terapia Financiera`
- hide decorative squares and switch to single-column grid when viewed on small screens

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6865e93f2650832291a0330452b65412