### PR TITLE
Update mobile header spacing

### DIFF
--- a/mobile.css
+++ b/mobile.css
@@ -12,6 +12,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    margin-bottom: -15px;
   }
   /* Estilo para el ícono del menú */
   .menu-wrapper {
@@ -251,6 +252,7 @@
   }
   .about-wrapper {
     height: auto;
+    margin-top: clamp(50px,10vh,65px);
   }
 
   .about-image img {


### PR DESCRIPTION
## Summary
- reduce spacing below mobile header with a negative bottom margin
- push the 'Sobre Mí' section down by the same amount as the header height on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686736610ad483228eccf325ce7e9d6d