### PR TITLE
Update mobile padding and width for about section

### DIFF
--- a/mobile.css
+++ b/mobile.css
@@ -247,7 +247,8 @@
   .about-section {
     flex-direction: column;
     gap: 20px;
-    padding: 3.5vw 1.75vw;
+    padding: 7vw 3.5vw;
+    width: 90%;
   }
   .about-wrapper {
     height: auto;


### PR DESCRIPTION
## Summary
- increase padding in the About section card on mobile
- widen the card to reduce side margins on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68673d222f6883228d9b8d1772bc5158