### PR TITLE
Update autodiagnóstico section with cards and progress bar

### DIFF
--- a/autodiagnostico.html
+++ b/autodiagnostico.html
@@ -78,42 +78,51 @@
     </div>
   </header>
 
-  <main class="container">
+  <main class="container autodiagnostico-container">
     <h1>Autodiagnóstico Financiero</h1>
-    <form id="diagnostico-form">
-      <div class="pregunta">
+    <form id="diagnostico-form" class="diagnostico-form">
+      <div class="pregunta card">
         <p>1. ¿Tus ingresos mensuales te permiten cubrir todos tus gastos sin endeudarte?</p>
         <label><input type="radio" name="p1" value="2" required> Sí, sin problema.</label>
         <label><input type="radio" name="p1" value="1"> A veces me alcanza.</label>
         <label><input type="radio" name="p1" value="0"> No, uso crédito.</label>
       </div>
 
-      <div class="pregunta">
+      <div class="pregunta card">
         <p>2. ¿Tienes deudas activas?</p>
         <label><input type="radio" name="p2" value="2" required> No tengo deudas.</label>
         <label><input type="radio" name="p2" value="1"> Las tengo bajo control.</label>
         <label><input type="radio" name="p2" value="0"> Me cuesta pagarlas.</label>
       </div>
 
-      <div class="pregunta">
+      <div class="pregunta card">
         <p>3. ¿Tienes un fondo de emergencia?</p>
         <label><input type="radio" name="p3" value="2" required> Sí, al menos 3 meses.</label>
         <label><input type="radio" name="p3" value="1"> Tengo algo.</label>
         <label><input type="radio" name="p3" value="0"> No tengo.</label>
       </div>
 
-      <div class="pregunta">
+      <div class="pregunta card">
         <p>4. ¿Sueles planificar tus gastos con un presupuesto?</p>
         <label><input type="radio" name="p4" value="2" required> Sí, llevo control mensual.</label>
         <label><input type="radio" name="p4" value="1"> A veces lo hago.</label>
         <label><input type="radio" name="p4" value="0"> No planifico.</label>
       </div>
 
-      <div class="pregunta">
+      <div class="pregunta card">
         <p>5. ¿Tienes metas financieras definidas?</p>
         <label><input type="radio" name="p5" value="2" required> Sí, tengo un plan.</label>
         <label><input type="radio" name="p5" value="1"> Tengo ideas, sin estructura.</label>
         <label><input type="radio" name="p5" value="0"> No he pensado en eso.</label>
+      </div>
+
+      <div class="nav-buttons">
+        <button type="button" id="btn-prev" class="btn-prev">Anterior</button>
+        <button type="button" id="btn-next" class="btn-next">Siguiente</button>
+      </div>
+
+      <div class="progress-container">
+        <div id="progress-bar" class="progress-bar"></div>
       </div>
     </form>
     <div id="resultado" class="resultado" style="display:none"></div>

--- a/autodiagnostico.js
+++ b/autodiagnostico.js
@@ -1,29 +1,51 @@
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('diagnostico-form');
-  const preguntas = form.querySelectorAll('.pregunta');
+  const preguntas = Array.from(form.querySelectorAll('.pregunta'));
   const resultado = document.getElementById('resultado');
+  const prevBtn = document.getElementById('btn-prev');
+  const nextBtn = document.getElementById('btn-next');
+  const progressBar = document.getElementById('progress-bar');
 
-  // Oculta todas las preguntas excepto la primera
-  preguntas.forEach((p, i) => {
-    if (i !== 0) p.style.display = 'none';
-    p.querySelectorAll('input[type="radio"]').forEach(radio => {
-      radio.addEventListener('change', () => mostrarSiguiente(i));
-    });
+  let indice = 0;
+  mostrarPregunta(indice);
+
+  prevBtn.addEventListener('click', () => {
+    if (indice > 0) {
+      indice--;
+      mostrarPregunta(indice);
+    }
   });
 
-  function mostrarSiguiente(indice) {
+  nextBtn.addEventListener('click', () => {
+    const current = preguntas[indice];
+    const checked = current.querySelector('input[type="radio"]:checked');
+    if (!checked) {
+      alert('Selecciona una opción');
+      return;
+    }
+
     if (indice < preguntas.length - 1) {
-      preguntas[indice].style.display = 'none';
-      preguntas[indice + 1].style.display = 'block';
+      indice++;
+      mostrarPregunta(indice);
     } else {
       form.style.display = 'none';
       mostrarResultado();
     }
+  });
+
+  function mostrarPregunta(i) {
+    preguntas.forEach((p, idx) => {
+      p.style.display = idx === i ? 'block' : 'none';
+    });
+
+    prevBtn.style.display = i === 0 ? 'none' : 'inline-block';
+    nextBtn.textContent = i === preguntas.length - 1 ? 'Finalizar' : 'Siguiente';
+    progressBar.style.width = (i / preguntas.length) * 100 + '%';
   }
 
   function mostrarResultado() {
     let puntaje = 0;
-    preguntas.forEach((p, idx) => {
+    preguntas.forEach(p => {
       const r = p.querySelector('input[type="radio"]:checked');
       if (r) puntaje += parseInt(r.value);
     });
@@ -41,6 +63,7 @@ document.addEventListener('DOMContentLoaded', () => {
       plan = 'Plan Transforma – Hacia la Proyección';
     }
 
+    progressBar.style.width = '100%';
     resultado.innerHTML =
       `<p>Tu estado financiero actual es <strong>${estado}</strong>. ` +
       `Te recomendamos el <strong>${plan}</strong>.</p>` +
@@ -48,6 +71,5 @@ document.addEventListener('DOMContentLoaded', () => {
     resultado.style.display = 'block';
   }
 
-  // Evita el envío del formulario por defecto
   form.addEventListener('submit', e => e.preventDefault());
 });

--- a/desk.css
+++ b/desk.css
@@ -1473,3 +1473,67 @@ section {
 #terapia-financiera ul li {
   margin-bottom: 0.75rem;
 }
+
+/*==================== AUTODIAGNÓSTICO ====================*/
+.autodiagnostico-container {
+  max-width: 600px;
+  margin: 20px auto;
+  padding: 20px;
+}
+
+.autodiagnostico-container h1 {
+  text-align: center;
+  margin-bottom: 20px;
+  color: var(--azul-medianoche);
+}
+
+.diagnostico-form .card {
+  background-color: #ffffff;
+  border: 1px solid #E0E6ED;
+  border-radius: 8px;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.06);
+  padding: 20px;
+  margin-bottom: 15px;
+}
+
+.diagnostico-form label {
+  display: block;
+  margin-bottom: 8px;
+}
+
+.nav-buttons {
+  display: flex;
+  justify-content: space-between;
+  margin: 20px 0;
+}
+
+.nav-buttons button {
+  background-color: var(--azul-profundo);
+  color: var(--blanco);
+  border: none;
+  border-radius: 5px;
+  padding: 10px 20px;
+  font-family: 'Montserrat', sans-serif;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.nav-buttons button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.progress-container {
+  width: 100%;
+  height: 6px;
+  background-color: #e0e0e0;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.progress-bar {
+  height: 100%;
+  width: 0;
+  background-color: var(--azul-profundo);
+  transition: width 0.3s ease;
+}

--- a/mobile.css
+++ b/mobile.css
@@ -554,3 +554,17 @@
 .hero-button:hover {
   background-color: #e05220;
 }
+
+/*==================== AUTODIAGNÓSTICO ====================*/
+.autodiagnostico-container {
+  padding: 20px 15px;
+}
+
+.nav-buttons {
+  flex-direction: column;
+  gap: 10px;
+}
+
+.nav-buttons button {
+  width: 100%;
+}


### PR DESCRIPTION
## Summary
- restyle the questionnaire cards in **autodiagnostico.html**
- add new autodiagnóstico styles for desktop and mobile
- implement navigation with progress bar in **autodiagnostico.js**

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6871962fd9d08322b956ff14c382cbaf