### PR TITLE
Improve autodiagnóstico form UX

### DIFF
--- a/autodiagnostico.html
+++ b/autodiagnostico.html
@@ -80,40 +80,41 @@
 
   <main class="container autodiagnostico-container">
     <h1>Autodiagnóstico Financiero</h1>
+    <div id="progress-text" class="progress-text"></div>
     <form id="diagnostico-form" class="diagnostico-form">
       <div class="pregunta card">
         <p>1. ¿Tus ingresos mensuales te permiten cubrir todos tus gastos sin endeudarte?</p>
-        <label><input type="radio" name="p1" value="2" required> Sí, sin problema.</label>
-        <label><input type="radio" name="p1" value="1"> A veces me alcanza.</label>
-        <label><input type="radio" name="p1" value="0"> No, uso crédito.</label>
+        <label><input type="radio" name="p1" value="2" required><span>Sí, sin problema.</span></label>
+        <label><input type="radio" name="p1" value="1"><span>A veces me alcanza.</span></label>
+        <label><input type="radio" name="p1" value="0"><span>No, uso crédito.</span></label>
       </div>
 
       <div class="pregunta card">
         <p>2. ¿Tienes deudas activas?</p>
-        <label><input type="radio" name="p2" value="2" required> No tengo deudas.</label>
-        <label><input type="radio" name="p2" value="1"> Las tengo bajo control.</label>
-        <label><input type="radio" name="p2" value="0"> Me cuesta pagarlas.</label>
+        <label><input type="radio" name="p2" value="2" required><span>No tengo deudas.</span></label>
+        <label><input type="radio" name="p2" value="1"><span>Las tengo bajo control.</span></label>
+        <label><input type="radio" name="p2" value="0"><span>Me cuesta pagarlas.</span></label>
       </div>
 
       <div class="pregunta card">
         <p>3. ¿Tienes un fondo de emergencia?</p>
-        <label><input type="radio" name="p3" value="2" required> Sí, al menos 3 meses.</label>
-        <label><input type="radio" name="p3" value="1"> Tengo algo.</label>
-        <label><input type="radio" name="p3" value="0"> No tengo.</label>
+        <label><input type="radio" name="p3" value="2" required><span>Sí, al menos 3 meses.</span></label>
+        <label><input type="radio" name="p3" value="1"><span>Tengo algo.</span></label>
+        <label><input type="radio" name="p3" value="0"><span>No tengo.</span></label>
       </div>
 
       <div class="pregunta card">
         <p>4. ¿Sueles planificar tus gastos con un presupuesto?</p>
-        <label><input type="radio" name="p4" value="2" required> Sí, llevo control mensual.</label>
-        <label><input type="radio" name="p4" value="1"> A veces lo hago.</label>
-        <label><input type="radio" name="p4" value="0"> No planifico.</label>
+        <label><input type="radio" name="p4" value="2" required><span>Sí, llevo control mensual.</span></label>
+        <label><input type="radio" name="p4" value="1"><span>A veces lo hago.</span></label>
+        <label><input type="radio" name="p4" value="0"><span>No planifico.</span></label>
       </div>
 
       <div class="pregunta card">
         <p>5. ¿Tienes metas financieras definidas?</p>
-        <label><input type="radio" name="p5" value="2" required> Sí, tengo un plan.</label>
-        <label><input type="radio" name="p5" value="1"> Tengo ideas, sin estructura.</label>
-        <label><input type="radio" name="p5" value="0"> No he pensado en eso.</label>
+        <label><input type="radio" name="p5" value="2" required><span>Sí, tengo un plan.</span></label>
+        <label><input type="radio" name="p5" value="1"><span>Tengo ideas, sin estructura.</span></label>
+        <label><input type="radio" name="p5" value="0"><span>No he pensado en eso.</span></label>
       </div>
 
       <div class="nav-buttons">

--- a/autodiagnostico.js
+++ b/autodiagnostico.js
@@ -5,6 +5,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const prevBtn = document.getElementById('btn-prev');
   const nextBtn = document.getElementById('btn-next');
   const progressBar = document.getElementById('progress-bar');
+  const progressText = document.getElementById('progress-text');
 
   let indice = 0;
   mostrarPregunta(indice);
@@ -35,12 +36,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function mostrarPregunta(i) {
     preguntas.forEach((p, idx) => {
-      p.style.display = idx === i ? 'block' : 'none';
+      p.classList.toggle('active', idx === i);
     });
 
     prevBtn.style.display = i === 0 ? 'none' : 'inline-block';
     nextBtn.textContent = i === preguntas.length - 1 ? 'Finalizar' : 'Siguiente';
     progressBar.style.width = (i / preguntas.length) * 100 + '%';
+    progressText.textContent = `Pregunta ${i + 1} de ${preguntas.length}`;
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   }
 
   function mostrarResultado() {
@@ -64,6 +67,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     progressBar.style.width = '100%';
+    progressText.textContent = 'Autodiagnóstico completado';
     resultado.innerHTML =
       `<p>Tu estado financiero actual es <strong>${estado}</strong>. ` +
       `Te recomendamos el <strong>${plan}</strong>.</p>` +

--- a/desk.css
+++ b/desk.css
@@ -1494,11 +1494,39 @@ section {
   box-shadow: 0 2px 5px rgba(0,0,0,0.06);
   padding: 20px;
   margin-bottom: 15px;
+  display: none;
+  opacity: 0;
+  transition: opacity 0.4s ease;
+}
+
+.diagnostico-form .card.active {
+  display: block;
+  opacity: 1;
 }
 
 .diagnostico-form label {
   display: block;
   margin-bottom: 8px;
+  padding: 10px;
+  border: 1px solid #E0E6ED;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.diagnostico-form label input[type="radio"] {
+  display: none;
+}
+
+.diagnostico-form label span {
+  display: inline-block;
+  width: 100%;
+}
+
+.diagnostico-form label input[type="radio"]:checked + span {
+  background-color: var(--azul-profundo);
+  color: var(--blanco);
+  font-weight: bold;
 }
 
 .nav-buttons {
@@ -1536,4 +1564,21 @@ section {
   width: 0;
   background-color: var(--azul-profundo);
   transition: width 0.3s ease;
+}
+
+.progress-text {
+  text-align: center;
+  margin-bottom: 10px;
+  font-weight: bold;
+  color: var(--azul-medianoche);
+}
+
+#resultado {
+  background-color: #ffffff;
+  border: 1px solid #E0E6ED;
+  border-radius: 8px;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.06);
+  padding: 20px;
+  margin-top: 20px;
+  text-align: center;
 }

--- a/mobile.css
+++ b/mobile.css
@@ -560,6 +560,10 @@
   padding: 20px 15px;
 }
 
+.progress-text {
+  margin-bottom: 15px;
+}
+
 .nav-buttons {
   flex-direction: column;
   gap: 10px;


### PR DESCRIPTION
## Summary
- add progress text container and wrap radio labels in spans
- style autodiagnóstico cards and options with transitions
- update progress bar text and result styling
- tweak mobile layout for new progress text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871a378dda48322a6309a98c3015998