### PR TITLE
Improve spacing in autodiagnostico section

### DIFF
--- a/desk.css
+++ b/desk.css
@@ -1475,15 +1475,16 @@ section {
 }
 
 /*==================== AUTODIAGNÓSTICO ====================*/
+
 .autodiagnostico-container {
   max-width: 600px;
-  margin: 20px auto;
+  margin: 40px auto;
   padding: 20px;
 }
 
 .autodiagnostico-container h1 {
   text-align: center;
-  margin-bottom: 20px;
+  margin-bottom: 40px;
   color: var(--azul-medianoche);
 }
 
@@ -1493,12 +1494,16 @@ section {
   border-radius: 8px;
   box-shadow: 0 2px 5px rgba(0,0,0,0.06);
   padding: 20px;
+  margin-bottom: 25px;
+}
+
+.diagnostico-form .card p {
   margin-bottom: 15px;
 }
 
 .diagnostico-form label {
   display: block;
-  margin-bottom: 8px;
+  margin-bottom: 12px;
 }
 
 .nav-buttons {

--- a/mobile.css
+++ b/mobile.css
@@ -558,6 +558,23 @@
 /*==================== AUTODIAGNÓSTICO ====================*/
 .autodiagnostico-container {
   padding: 20px 15px;
+  margin-top: 30px;
+}
+
+.autodiagnostico-container h1 {
+  margin-bottom: 30px;
+}
+
+.diagnostico-form .card {
+  margin-bottom: 25px;
+}
+
+.diagnostico-form .card p {
+  margin-bottom: 15px;
+}
+
+.diagnostico-form label {
+  margin-bottom: 12px;
 }
 
 .nav-buttons {


### PR DESCRIPTION
## Summary
- increase margin before autodiagnóstico heading
- add more spacing around question blocks and labels
- adjust mobile styles accordingly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871aa4c3df88322a73f4652c0120242