### PR TITLE
Mejoras en autodiagnóstico

### DIFF
--- a/autodiagnostico.html
+++ b/autodiagnostico.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Autodiagnóstico Financiero</title>
+  <title>Autodiagnóstico de Bienestar Financiero</title>
   <link rel="stylesheet" href="desk.css" />
   <link rel="stylesheet" href="mobile.css" media="screen and (max-width: 768px)">
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;700&display=swap" rel="stylesheet">
@@ -79,7 +79,7 @@
   </header>
 
   <main class="container autodiagnostico-container">
-    <h1>Autodiagnóstico Financiero</h1>
+    <h1>Autodiagnóstico de Bienestar Financiero</h1>
     <form id="diagnostico-form" class="diagnostico-form">
       <div class="pregunta card">
         <p>1. ¿Tus ingresos mensuales te permiten cubrir todos tus gastos sin endeudarte?</p>

--- a/autodiagnostico.js
+++ b/autodiagnostico.js
@@ -54,29 +54,29 @@ document.addEventListener('DOMContentLoaded', () => {
     if (puntaje <= 3) {
       mensaje = `
         <h2>✅ Resultado del diagnóstico financiero personal</h2>
-        <p>🔎 Tu estado actual es: Supervivencia Financiera</p>
+        <p>🔎 Tu estado actual es: <strong>Supervivencia Financiera</strong></p>
         <p>Estás en una etapa donde el ingreso apenas alcanza para cubrir lo básico. Probablemente vives al día, sin margen para ahorrar o responder ante imprevistos. Esto puede generar mucho estrés y una sensación de estar atrapado/a en un ciclo difícil de romper.</p>
-        <p>📍 ¿Cómo mejorar?<br>Te recomendamos el Plan “Inicia – Hacia la Estabilidad Financiera”, diseñado para ayudarte a tomar el control de tus gastos, ordenar tus finanzas y generar tus primeros ahorros.</p>
+        <p>📍 ¿Cómo mejorar?<br>Te recomendamos el plan <strong>Inicia – Hacia la Estabilidad Financiera</strong>, diseñado para ayudarte a tomar el control de tus gastos, ordenar tus finanzas y generar tus primeros ahorros.</p>
         <p>👥 ¿Cómo son las personas que están en el siguiente estado?<br>Son personas que ya logran cubrir sus gastos con cierta holgura, tienen pequeños colchones financieros y comienzan a mirar el mediano plazo. No todo está resuelto, pero ya respiran con más tranquilidad.</p>
-        <p>🧭 Con el plan “Inicia”, vamos a sentar las bases para que tú también salgas del modo supervivencia y empieces a construir estabilidad. Paso a paso, sin juicios, pero con dirección.</p>
+        <p>🧭 Con el plan <strong>Inicia</strong>, vamos a sentar las bases para que tú también salgas del modo supervivencia y empieces a construir estabilidad. Paso a paso, sin juicios, pero con dirección.</p>
       `;
     } else if (puntaje <= 6) {
       mensaje = `
         <h2>✅ Resultado del diagnóstico financiero personal</h2>
-        <p>🔎 Tu estado actual es: Estabilidad Financiera</p>
+        <p>🔎 Tu estado actual es: <strong>Estabilidad Financiera</strong></p>
         <p>Tus finanzas están bajo control. Cubres tus necesidades y quizás tienes algo de ahorro, pero todavía falta estrategia. No estás en riesgo, pero tampoco estás sacando el mayor provecho a tu dinero.</p>
-        <p>📍 ¿Cómo mejorar?<br>Te recomendamos el Plan “Potencia – Hacia la Tranquilidad Financiera”, que te ayudará a optimizar lo que ya lograste: ahorrar con propósito, invertir y planificar tus próximos pasos con intención.</p>
+        <p>📍 ¿Cómo mejorar?<br>Te recomendamos el plan <strong>Potencia – Hacia la Tranquilidad Financiera</strong>, que te ayudará a optimizar lo que ya lograste: ahorrar con propósito, invertir y planificar tus próximos pasos con intención.</p>
         <p>👥 ¿Cómo son las personas que están en el siguiente estado?<br>Son personas que ya viven con tranquilidad financiera. Tienen fondos de emergencia, ahorros definidos y una planificación clara. Su dinero no solo cubre sus necesidades, también les permite avanzar hacia sus metas.</p>
-        <p>🧭 Con el plan “Potencia”, vas a estructurar lo que hasta ahora has manejado de forma más intuitiva. Es momento de que tu dinero trabaje para ti.</p>
+        <p>🧭 Con el plan <strong>Potencia</strong>, vas a estructurar lo que hasta ahora has manejado de forma más intuitiva. Es momento de que tu dinero trabaje para ti.</p>
       `;
     } else {
       mensaje = `
         <h2>✅ Resultado del diagnóstico financiero personal</h2>
-        <p>🔎 Tu estado actual es: Tranquilidad Financiera</p>
+        <p>🔎 Tu estado actual es: <strong>Tranquilidad Financiera</strong></p>
         <p>Has hecho un gran trabajo: tienes tus finanzas ordenadas, ahorras de forma constante y no dependes de deudas para vivir tranquilo. Ya no hay sobresaltos. Pero aún hay espacio para ir más allá.</p>
-        <p>📍 ¿Cómo mejorar?<br>Te recomendamos el Plan “Transforma – Hacia la Proyección Financiera”, que te permitirá usar tu estabilidad como plataforma para construir patrimonio, invertir estratégicamente y pensar en tu futuro con visión de largo plazo.</p>
+        <p>📍 ¿Cómo mejorar?<br>Te recomendamos el plan <strong>Transforma – Hacia la Proyección Financiera</strong>, que te permitirá usar tu estabilidad como plataforma para construir patrimonio, invertir estratégicamente y pensar en tu futuro con visión de largo plazo.</p>
         <p>👥 ¿Cómo son las personas que están en el siguiente estado?<br>Son personas que ya no solo piensan en estar bien hoy, sino en construir el mañana. Tienen objetivos financieros de mediano y largo plazo, aprovechan oportunidades para hacer crecer su dinero y proyectan su estilo de vida futuro con intención.</p>
-        <p>🧭 Con el plan “Transforma”, vas a pasar del orden al crecimiento. Este es el punto donde se consolida tu tranquilidad y comienza la planificación activa de tu libertad financiera.</p>
+        <p>🧭 Con el plan <strong>Transforma</strong>, vas a pasar del orden al crecimiento. Este es el punto donde se consolida tu tranquilidad y comienza la planificación activa de tu libertad financiera.</p>
       `;
     }
 

--- a/desk.css
+++ b/desk.css
@@ -1542,3 +1542,26 @@ section {
   background-color: var(--azul-profundo);
   transition: width 0.3s ease;
 }
+
+/* Resultado del autodiagnóstico */
+.resultado {
+  font-family: 'Montserrat', sans-serif;
+  color: var(--azul-medianoche);
+  line-height: 1.6;
+  font-size: 1rem;
+  margin-top: 20px;
+}
+
+.resultado h2 {
+  font-size: 1.4rem;
+  margin-bottom: 1rem;
+}
+
+.resultado p {
+  margin-bottom: 1rem;
+}
+
+.resultado .hero-button {
+  display: block;
+  margin: 2rem auto 0;
+}

--- a/mobile.css
+++ b/mobile.css
@@ -585,3 +585,26 @@
 .nav-buttons button {
   width: 100%;
 }
+
+/* Resultado del autodiagnóstico */
+.resultado {
+  font-family: 'Montserrat', sans-serif;
+  color: var(--azul-medianoche);
+  line-height: 1.6;
+  font-size: 1rem;
+  margin-top: 20px;
+}
+
+.resultado h2 {
+  font-size: 1.3rem;
+  margin-bottom: 1rem;
+}
+
+.resultado p {
+  margin-bottom: 1rem;
+}
+
+.resultado .hero-button {
+  display: block;
+  margin: 2rem auto 0;
+}


### PR DESCRIPTION
## Summary
- ajustar título y encabezado en autodiagnóstico
- aplicar estilos a los resultados
- resaltar nombres en el resultado

## Testing
- `npm test` *(falla: no se encontró `package.json`)*
- `pytest` *(sin tests)*

------
https://chatgpt.com/codex/tasks/task_e_687252319c208322b62e59fb648539b8