### PR TITLE
Update accordion spacing and reorganize financial states

### DIFF
--- a/desk.css
+++ b/desk.css
@@ -1337,6 +1337,7 @@ section {
   color: inherit;
   border: none;
   padding: 10px 20px;
+  padding-right: 40px;          /* deja espacio para el símbolo */
   cursor: pointer;
   position: relative;           /* para poder posicionar el "+" */
   font-size: 1rem;              /* mismo tamaño que el texto */

--- a/index.html
+++ b/index.html
@@ -207,10 +207,6 @@ src="https://www.facebook.com/tr?id=1263310729136170&ev=PageView&noscript=1"
             Tienes control total de tus finanzas: ahorras, planificas y no dependes del crédito. Puedes enfrentar imprevistos sin desestabilizarte. Tu enfoque empieza a moverse del presente hacia el futuro.
           </div>
         </div>
-      </div>
-    </div>
-    <div class="tf-row tf-row2">
-      <div class="tf-ii">
         <div class="accordion-item">
           <button class="accordion-title">🔵 4. Proyección Financiera</button>
           <div class="accordion-content">
@@ -223,6 +219,10 @@ src="https://www.facebook.com/tr?id=1263310729136170&ev=PageView&noscript=1"
             Tu situación económica te permite decidir sin que el dinero sea un obstáculo. Ingresos pasivos o inversiones cubren tus necesidades. Ya no solo gestionas tu dinero: lo usas como herramienta para vivir en tus propios términos.
           </div>
         </div>
+      </div>
+    </div>
+    <div class="tf-row tf-row2">
+      <div class="tf-ii">
       </div>
       <div class="tf-id">
       <h3>Está dirigido a quienes:</h3>


### PR DESCRIPTION
## Summary
- move all financial state items into the SD block
- leave the II block empty
- add right padding on accordion titles so the `+` symbol aligns at the far right

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68729c0f74888322b001f2c920127982