### PR TITLE
Ajustar ancho del menú mobile

### DIFF
--- a/mobile.css
+++ b/mobile.css
@@ -73,11 +73,12 @@
   flex-direction: column;
   position: fixed;
   top: 0;
-  left: -75vw;            /* Fuera de la pantalla a la izquierda */
-  width: 75vw;
+  left: 0;
+  width: fit-content;
   height: 100vh;
   background-color: #1e293b;  /* O el color que prefieras */
-  transition: left 0.3s ease;  /* Transición para el deslizamiento */
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;  /* Transición para el deslizamiento */
   z-index: 998;           /* Debe estar sobre el contenido, pero debajo del header si éste tiene z-index mayor */
   padding-top: clamp(60px, 10vh, 80px); /* Opcional, para dejar espacio por el header */
   border-radius: 5px;
@@ -85,7 +86,7 @@
 
 /* Estado activo (cuando se hace clic en el menú) */
 .mobile-menu.active {
-  left: 0;  /* Se desliza hacia adentro */
+  transform: translateX(0);  /* Se desliza hacia adentro */
 }
 
 /* Opcional: estilos para los links del menú */
@@ -547,7 +548,7 @@
   .menu-wrapper,
   .header-agendar { width: 160px; }
   .hero-banner { margin-top: -10px; height: 100vh; }
-  .mobile-menu { left: -85vw; width: 85vw; }
+  .mobile-menu { max-width: 85vw; }
   .about-wrapper { height: auto; }
   .about-image img { width: 70vw; margin-top: 5vh; }
   .contacto-wrapper { margin: 20px auto; }


### PR DESCRIPTION
## Summary
- Ajusta el menú hamburguesa móvil para que su ancho se adapte al texto.
- Sustituye el desplazamiento por `transform` y elimina la anchura fija.
- Actualiza estilos para pantallas muy pequeñas.

## Testing
- `npm test` *(falla: ENOENT no encuentra package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fa550a20883228b50c14f1687efc1