### PR TITLE
Reestructura simulador de créditos en versión móvil

### DIFF
--- a/desk.css
+++ b/desk.css
@@ -1222,6 +1222,13 @@ section {
   visibility: visible;
 }
 
+/* Elementos de la tabla de desarrollo (ocultos en escritorio) */
+.tabla-btn,
+#closeTabla,
+.tabla-overlay {
+  display: none;
+}
+
 /* ===== Sección Educación ===== */
 /* ===== Sección Educación ===== */
 /* ===== Sección Educación ===== */

--- a/mobile.css
+++ b/mobile.css
@@ -475,6 +475,77 @@
   visibility: visible;
 }
 
+/* Ajustes para el simulador de créditos en móvil */
+.simulador-container {
+  flex-direction: column;
+}
+
+.simulador-info {
+  margin-top: 20px;
+}
+
+/* Botón para mostrar la tabla de desarrollo */
+.tabla-btn {
+  display: block;
+  background-color: #ff6b35;
+  color: #ffffff;
+  border: none;
+  padding: 8px 16px;
+  margin: 20px auto;
+  border-radius: 4px;
+  font-weight: 600;
+}
+
+/* Panel y overlay del cuadro de desarrollo */
+#tablaPanel {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  width: 90vw;
+  max-height: 80vh;
+  overflow-y: auto;
+  background: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.25);
+  transform: translate(-50%, -50%) scale(0.8);
+  opacity: 0;
+  visibility: hidden;
+  z-index: 1000;
+  transition: all 0.3s ease;
+}
+
+#tablaPanel.active {
+  transform: translate(-50%, -50%) scale(1);
+  opacity: 1;
+  visibility: visible;
+}
+
+#closeTabla {
+  display: block;
+  background: transparent;
+  border: none;
+  font-size: 1.2rem;
+  margin-left: auto;
+  cursor: pointer;
+}
+
+.tabla-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0,0,0,0.5);
+  opacity: 0;
+  visibility: hidden;
+  z-index: 999;
+  transition: opacity 0.3s ease;
+}
+
+.tabla-overlay.active {
+  opacity: 1;
+  visibility: visible;
+}
 
 }
 

--- a/simulador.html
+++ b/simulador.html
@@ -372,8 +372,15 @@
 </div>
 
 
+<!-- Botón para desplegar el cuadro de desarrollo -->
+<button id="toggleTabla" class="tabla-btn">Ver desarrollo del crédito</button>
+
 <!-- Cuadro de desarrollo de pagos (tabla) -->
-<div class="simulador-tabla" id="resultado"></div>
+<div id="tablaPanel">
+  <button id="closeTabla" class="tabla-close-btn">✕ Cerrar</button>
+  <div class="simulador-tabla" id="resultado"></div>
+</div>
+<div id="tablaOverlay" class="tabla-overlay"></div>
 
 </div>
 

--- a/simulador.js
+++ b/simulador.js
@@ -570,3 +570,23 @@ document.querySelectorAll(".mobile-menu a").forEach(link => {
   });
 });
 
+// Mostrar/ocultar la tabla de desarrollo en versión móvil
+const btnTabla = document.getElementById('toggleTabla');
+const panelTabla = document.getElementById('tablaPanel');
+const overlayTabla = document.getElementById('tablaOverlay');
+const btnCerrarTabla = document.getElementById('closeTabla');
+
+if (btnTabla && panelTabla && overlayTabla && btnCerrarTabla) {
+  const abrirTabla = () => {
+    panelTabla.classList.add('active');
+    overlayTabla.classList.add('active');
+  };
+  const cerrarTabla = () => {
+    panelTabla.classList.remove('active');
+    overlayTabla.classList.remove('active');
+  };
+  btnTabla.addEventListener('click', abrirTabla);
+  btnCerrarTabla.addEventListener('click', cerrarTabla);
+  overlayTabla.addEventListener('click', cerrarTabla);
+}
+


### PR DESCRIPTION
## Summary
- Ordena bloques del simulador de crédito para que formulario y cálculos se apilen verticalmente en móviles.
- Agrega botón naranja para mostrar el cuadro de desarrollo y usa un overlay para atenuar la página al desplegarlo.
- Oculta elementos del cuadro de desarrollo en versión escritorio y añade lógica JS para abrir/cerrar el panel.

## Testing
- `node --check simulador.js`


------
https://chatgpt.com/codex/tasks/task_e_689fc340f0808322bf729a1315131376