### PR TITLE
Estiliza resultados del simulador de créditos

### DIFF
--- a/desk.css
+++ b/desk.css
@@ -850,30 +850,33 @@ section {
   margin-bottom: 15px;
 }
 
-/* Cada ítem de información: Flex para separar label y valor */
+/* Cada ítem de información */
 .info-item {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
   width: 100%;
-  margin-bottom: 10px;
+  margin-bottom: 15px;
   color: #2E4057;
-  font-size: clamp(0.475rem, 1.05vw, 0.95rem);
+  font-family: 'Montserrat', sans-serif;
+  font-size: clamp(0.9rem, 1.2vw, 1.2rem);
   font-weight: 400;
   line-height: 1.3;
 }
 
-/* Etiqueta en la info (izquierda) */
+/* Etiqueta en la info */
 .info-label {
-  flex: 0 0 300px;
+  flex: none;
+  margin-bottom: 5px;
   text-align: left;
+  font-weight: 600;
 }
 
-/* Valor en la info (derecha) */
+/* Valor en la info */
 .info-value {
-  flex: 1;
-  text-align: right;
-  margin-left: 20px;
+  flex: none;
+  text-align: left;
+  margin-left: 0;
 }
 
 /* Simulador Tabla (cuadro de pagos) */


### PR DESCRIPTION
## Summary
- Aplica tipografía y tamaños del formulario a los resultados del simulador.
- Coloca los títulos de cada dato sobre su resultado y los alinea a la izquierda.

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fc97b0f18832293ac79042463b9ce