### PR TITLE
Add confirmation page with countdown after form submission

### DIFF
--- a/confirmacion.html
+++ b/confirmacion.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Confirmación</title>
+  <link rel="icon" href="favicon.png" type="image/png">
+  <link rel="stylesheet" href="desk.css">
+  <link rel="stylesheet" href="mobile.css" media="screen and (max-width: 768px)">
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;700&display=swap" rel="stylesheet">
+  <style>
+    body, html {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+      font-family: 'Montserrat', sans-serif;
+    }
+    .confirmation-container {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      text-align: center;
+      height: 100%;
+      padding: 0 1rem;
+    }
+    h1 {
+      margin-bottom: 1rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="confirmation-container">
+    <h1>¡Formulario enviado con éxito!</h1>
+    <p>Serás redirigido a la página principal en <span id="countdown">5</span> segundos.</p>
+  </div>
+  <script>
+    let seconds = 5;
+    const countdownEl = document.getElementById('countdown');
+    const interval = setInterval(() => {
+      seconds--;
+      countdownEl.textContent = seconds;
+      if (seconds <= 0) {
+        clearInterval(interval);
+        window.location.href = 'index.html';
+      }
+    }, 1000);
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -279,13 +279,16 @@
   document.getElementById('contact-form').addEventListener('submit', function(event) {
     event.preventDefault();
 
+    const submitButton = this.querySelector('button[type="submit"]');
+    submitButton.disabled = true;
+
     emailjs.sendForm('service_y83brs4', 'template_lfl253t', this)
       .then(function() {
-        document.getElementById('respuesta').innerText = "✅ ¡Mensaje enviado con éxito!";
-        document.getElementById('contact-form').reset();
+        window.location.href = "confirmacion.html";
       }, function(error) {
         document.getElementById('respuesta').innerText = "❌ Ocurrió un error. Intenta más tarde.";
         console.error("EmailJS error:", error);
+        submitButton.disabled = false;
       });
   });
 </script>


### PR DESCRIPTION
## Summary
- create confirmation page that thanks users for submitting and counts down 5 seconds
- redirect form submission to the confirmation page instead of inline message
- disable form's submit button during EmailJS request to avoid duplicate emails

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af92488978832293b37bdeaa46c8c7