### PR TITLE
Add FAQ accordion section after Terapia Financiera

### DIFF
--- a/desk.css
+++ b/desk.css
@@ -1542,6 +1542,38 @@ section {
   margin-bottom: 0.75rem;
 }
 
+#faq {
+  padding: 4rem 0;
+  margin-left: 0;
+  margin-right: 0;
+  border-radius: 20px;
+  overflow: hidden;
+  background-color: transparent;
+  color: #333;
+  font-family: 'Montserrat', sans-serif;
+}
+
+#faq .faq-grid {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+#faq .section-title {
+  font-size: 2rem;
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+  color: #111;
+}
+
+#faq .accordion-title {
+  font-size: 1.25rem;
+  line-height: 1.6;
+}
+
+#faq .accordion-item {
+  margin-bottom: 16px;
+}
+
 /*==================== AUTODIAGNÓSTICO ====================*/
 
 .autodiagnostico-container {

--- a/index.html
+++ b/index.html
@@ -235,6 +235,74 @@
 
 
 
+<section id="faq" class="section">
+  <div class="faq-grid">
+    <h2 class="section-title">Preguntas Frecuentes (FAQ)</h2>
+    <div class="faq">
+      <div class="accordion-item">
+        <button class="accordion-title"><strong>¿Qué es la Terapia Financiera?</strong></button>
+        <div class="accordion-content">
+          Es un proceso práctico de educación y acompañamiento que busca ordenar tus finanzas personales, reducir el estrés financiero y ayudarte a tomar decisiones claras. No se trata de austeridad, sino de usar el dinero como una herramienta para lograr tus objetivos de vida.
+        </div>
+      </div>
+      <div class="accordion-item">
+        <button class="accordion-title"><strong>¿En qué se diferencia de una asesoría financiera tradicional?</strong></button>
+        <div class="accordion-content">
+          Aquí no vendemos un producto asociado a la problemática. El enfoque es independiente y educativo: entrego claridad con herramientas, simuladores y un plan aplicable a tu realidad, sin conflictos de interés.
+        </div>
+      </div>
+      <div class="accordion-item">
+        <button class="accordion-title"><strong>¿Qué puedo esperar de una sesión 1:1?</strong></button>
+        <div class="accordion-content">
+          En cada sesión revisamos tu situación financiera actual, definimos tus objetivos y trabajamos con simuladores o ejercicios prácticos (créditos, inversiones, presupuestos). Te llevas pasos concretos para avanzar y materiales de apoyo.
+        </div>
+      </div>
+      <div class="accordion-item">
+        <button class="accordion-title"><strong>¿Necesito conocimientos previos de finanzas?</strong></button>
+        <div class="accordion-content">
+          No. La idea es justamente partir desde cero si es necesario. Los conceptos se explican de manera sencilla y aplicados a tu vida diaria.
+        </div>
+      </div>
+      <div class="accordion-item">
+        <button class="accordion-title"><strong>¿Cuánto duran las sesiones y cómo se realizan?</strong></button>
+        <div class="accordion-content">
+          Cada sesión dura alrededor de 45 minutos y se realiza de forma online, para que puedas conectarte desde cualquier lugar.
+        </div>
+      </div>
+      <div class="accordion-item">
+        <button class="accordion-title"><strong>¿Los simuladores reemplazan la asesoría?</strong></button>
+        <div class="accordion-content">
+          No. Los simuladores son herramientas de apoyo para visualizar escenarios. La asesoría agrega interpretación, estrategia y un plan personalizado para ti.
+        </div>
+      </div>
+      <div class="accordion-item">
+        <button class="accordion-title"><strong>¿Qué pasa si ya tengo deudas?</strong></button>
+        <div class="accordion-content">
+          Podemos trabajar en un plan de orden y pago, evaluando alternativas para reducir costos financieros y evitar que el ciclo de endeudamiento siga creciendo.
+        </div>
+      </div>
+      <div class="accordion-item">
+        <button class="accordion-title"><strong>¿La asesoría incluye inversiones?</strong></button>
+        <div class="accordion-content">
+          Sí, revisamos opciones de inversión según tu perfil y objetivos, siempre de forma general y educativa. No entrego recomendaciones específicas de compra o venta, sino que te enseño a comparar y decidir con criterio.
+        </div>
+      </div>
+      <div class="accordion-item">
+        <button class="accordion-title"><strong>¿Cómo agendo una sesión?</strong></button>
+        <div class="accordion-content">
+          Puedes hacerlo directamente desde la sección Agendar en esta página. Allí eliges día y la hora.
+        </div>
+      </div>
+      <div class="accordion-item">
+        <button class="accordion-title"><strong>¿Quién puede tomar estas asesorías?</strong></button>
+        <div class="accordion-content">
+          Cualquier persona que quiera mejorar su relación con el dinero, aprender a manejar créditos, ordenar sus finanzas personales o comenzar a invertir de forma informada.
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
 <!-- SDK de EmailJS -->
 <script src="https://cdn.jsdelivr.net/npm/@emailjs/browser@3/dist/email.min.js"></script>
 <script>

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
 // Acordeones para estados financieros
 document.addEventListener('DOMContentLoaded', function () {
-  const items = document.querySelectorAll('.tf-sd .accordion-item, .tf-ii .accordion-item');
+  const items = document.querySelectorAll('.tf-sd .accordion-item, .tf-ii .accordion-item, #faq .accordion-item');
   items.forEach(item => {
     const title = item.querySelector('.accordion-title');
     const content = item.querySelector('.accordion-content');

--- a/mobile.css
+++ b/mobile.css
@@ -276,7 +276,20 @@
     text-align: center;
   }
 
+  #faq {
+    margin-left: 0;
+    margin-right: 0;
+    background-color: transparent;
+  }
 
+  #faq .section-title {
+    text-align: center;
+    font-size: 1.6rem;
+    font-weight: 700;
+    margin: 1rem 0;
+  }
+
+  
   .about-section {
     flex-direction: column;
     gap: 20px;
@@ -415,7 +428,7 @@
   width: auto;
   text-align: left;
   background: transparent;
-  padding: 15px;
+  padding: 15px 40px 15px 15px;
   cursor: pointer;
   border: none;
   color: inherit;
@@ -424,20 +437,24 @@
   font-weight: 600;
   border-radius: 10px;
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  position: relative;
 }
 
 .accordion-title::after {
   content: "+";
   font-weight: bold;
   color: #ff6b35;
+  position: absolute;
+  right: 15px;
+  top: 50%;
+  transform: translateY(-50%);
   transition: transform 0.2s ease;
 }
 
 .accordion-item.active .accordion-title::after {
   content: "-";
-  transform: rotate(180deg);
+  transform: translateY(-50%) rotate(180deg);
 }
 
 .accordion-content {


### PR DESCRIPTION
## Summary
- enlarge FAQ question titles and spacing in desktop to match site typography
- revise second FAQ response wording to remove bank reference
- prevent plus/minus icons overlapping text in mobile by adding right padding and absolute positioning

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b10ca078a08322a1b9a74b9a4cfcae