### PR TITLE
Ajusta estilos de Educación para Bancos y Finanzas

### DIFF
--- a/desk.css
+++ b/desk.css
@@ -1393,7 +1393,6 @@ section {
 
 .accordion-title-text strong {
   font-size: clamp(0.9rem, 1.1vw, 1.1rem);
-  color: #fff;
 }
 
 /* mover el “+” al extremo derecho */
@@ -1423,6 +1422,25 @@ section {
 
 .accordion-item.active .accordion-content {
   display: block;
+}
+
+/* ===== Estilo específico para los acordeones de la página Educación ===== */
+#education-content .accordion-item {
+  background: #ffffff;
+  border-radius: 10px;
+  box-shadow: 0 0 10px rgba(0,0,0,0.05);
+}
+
+#education-content .accordion-title {
+  color: var(--azul-profundo);
+}
+
+#education-content .accordion-title-text strong {
+  color: var(--azul-profundo);
+}
+
+#education-content .accordion-title::after {
+  color: #ff6b35;
 }
 #terapia-financiera {
   padding: 4rem 0;

--- a/mobile.css
+++ b/mobile.css
@@ -470,6 +470,15 @@
   display: block;
 }
 
+/* Estilo específico para la página Educación */
+#education-content .accordion-title {
+  color: var(--azul-profundo);
+}
+
+#education-content .accordion-title-text strong {
+  color: var(--azul-profundo);
+}
+
 
 
 /* Overlay: inicialmente oculto */


### PR DESCRIPTION
## Summary
- Normaliza color del título de los acordeones en Educación.
- Aplica fondo y sombra a los acordeones de "Aprende de Bancos" y "Aprende de Finanzas".
- Ajusta estilos móviles para mantener coherencia de color.

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b11a121f348322afb7ce7aba21d3ac