### PR TITLE
Add i18n support to education, simulator, investments and blog pages

### DIFF
--- a/blog/blog.js
+++ b/blog/blog.js
@@ -16,6 +16,21 @@ function parseFrontMatter(md) {
   return { meta: {}, content: md };
 }
 
+const getTranslation = (key, fallback) => {
+  if (window.t) {
+    const translated = window.t(key);
+    return translated === key ? fallback : translated;
+  }
+  return fallback;
+};
+
+const updateBlogImageAlts = () => {
+  const altText = getTranslation('blog.postImageAlt', 'Imagen del post');
+  document.querySelectorAll('.blog-image').forEach((img) => {
+    img.setAttribute('alt', altText);
+  });
+};
+
 document.addEventListener('DOMContentLoaded', function() {
   const repo = 'nmoroso/nicolasmoroso-paginaweb';
   const branch = 'main';
@@ -70,17 +85,23 @@ document.addEventListener('DOMContentLoaded', function() {
         const wrapper = document.createElement('div');
         wrapper.className = 'blog-post-wrapper';
 
+        const altText = getTranslation('blog.postImageAlt', 'Imagen del post');
         wrapper.innerHTML = `
           <div class="blog-header">
             <h1 class="blog-title">${meta.title || ''}</h1>
             <p class="blog-date">${formattedDate}</p>
           </div>
-          ${imageUrl ? `<div class="blog-image-wrapper"><img src="${resolvedImageUrl}" alt="Imagen del post" class="blog-image" onerror="this.style.display='none'; console.warn('⚠️ No se pudo cargar la imagen:', this.src);"></div>` : ''}
+          ${imageUrl ? `<div class="blog-image-wrapper"><img src="${resolvedImageUrl}" alt="${altText}" class="blog-image" onerror="this.style.display='none'; console.warn('⚠️ No se pudo cargar la imagen:', this.src);"></div>` : ''}
           <div class="blog-content">${html}</div>
         `;
 
         container.appendChild(wrapper);
       });
     })
+    .then(() => updateBlogImageAlts())
     .catch(err => console.error('Error cargando posts', err));
+});
+
+window.addEventListener('languageChanged', () => {
+  updateBlogImageAlts();
 });

--- a/blog/index.html
+++ b/blog/index.html
@@ -31,7 +31,7 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
 <!-- End Meta Pixel Code -->
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Blog</title>
+  <title data-i18n="blog.meta.title">Blog</title>
 
   <link rel="icon" href="../favicon.png" type="image/png">
   <link rel="stylesheet" href="../desk.css">
@@ -111,7 +111,7 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
       <div class="header-logo">
         <a href="../index.html" class="logo">
           <img src="../logo.png" alt="Terapia Financiera" />
-          <span class="logo-text">
+          <span class="logo-text" data-i18n-html="nav.home">
           inicio<span class="orange-f"></span>
           </span>
         </a>
@@ -120,38 +120,46 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
         <ul>
           <li>
 
-            <a href="../educacion.html" class="nav-item">Educación</a>
+            <a href="../educacion.html" class="nav-item" data-i18n="nav.education">Educación</a>
           </li>
           <li class="simulador-dropdown">
-            <a href="#simulador" class="nav-item">Simulador</a>
+            <a href="#simulador" class="nav-item" data-i18n="nav.simulator">Simulador</a>
 
             <ul class="simulador-menu">
-              <li><a href="../simulador.html" class="submenu-item">Créditos</a></li>
-              <li><a href="../inversiones.html" class="submenu-item">Inversiones</a></li>
+              <li><a href="../simulador.html" class="submenu-item" data-i18n="nav.simulatorCredits">Créditos</a></li>
+              <li><a href="../inversiones.html" class="submenu-item" data-i18n="nav.simulatorInvestments">Inversiones</a></li>
             </ul>
           </li>
-          <li><a href="index.html" class="nav-item"><span class="orange-f">Blog</span></a></li>
-          <li><a href="../index.html#about" class="nav-item">Sobre Mí</a></li>
+          <li><a href="index.html" class="nav-item"><span class="orange-f" data-i18n="nav.blog">Blog</span></a></li>
+          <li><a href="../index.html#about" class="nav-item" data-i18n="nav.about">Sobre Mí</a></li>
         </ul>
       </nav>
-      <div class="header-agendar">
-        <a href="https://encuadrado.com/p/nicolas-moroso-1/" class="header-button desk-btn">AGENDAR</a>
-        <a href="https://encuadrado.com/p/nicolas-moroso-1/" class="header-button mobile-btn">AGENDAR</a>
+      <div class="header-actions">
+        <div class="header-agendar">
+          <a href="https://encuadrado.com/p/nicolas-moroso-1/" class="header-button desk-btn" data-i18n="nav.schedule">AGENDAR</a>
+          <a href="https://encuadrado.com/p/nicolas-moroso-1/" class="header-button mobile-btn" data-i18n="nav.schedule">AGENDAR</a>
+        </div>
+
+        <div class="language-toggle" aria-label="Selector de idioma">
+          <button type="button" class="language-toggle-button" data-lang="es">ES</button>
+          <span class="language-toggle-separator">|</span>
+          <button type="button" class="language-toggle-button" data-lang="en">EN</button>
+        </div>
       </div>
       <div class="mobile-menu">
         <ul>
 
-          <li><a href="../educacion.html">Educación</a></li>
+          <li><a href="../educacion.html" data-i18n="nav.education">Educación</a></li>
           <li class="simulador-dropdown">
-            <a>Simulador</a>
+            <a data-i18n="nav.simulator">Simulador</a>
 
             <ul class="simulador-menu">
-              <li><a href="../simulador.html" class="submenu-item">Créditos</a></li>
-              <li><a href="../inversiones.html" class="submenu-item">Inversiones</a></li>
+              <li><a href="../simulador.html" class="submenu-item" data-i18n="nav.simulatorCredits">Créditos</a></li>
+              <li><a href="../inversiones.html" class="submenu-item" data-i18n="nav.simulatorInvestments">Inversiones</a></li>
             </ul>
           </li>
-          <li><a href="index.html"><span class="orange-f">Blog</span></a></li>
-          <li><a href="../index.html#about">Sobre Mí</a></li>
+          <li><a href="index.html"><span class="orange-f" data-i18n="nav.blog">Blog</span></a></li>
+          <li><a href="../index.html#about" data-i18n="nav.about">Sobre Mí</a></li>
         </ul>
       </div>
     </div>
@@ -164,10 +172,10 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
   <footer id="contact">
     <div class="footer-container">
       <div class="footer-logo">
-        <h2>nicolasmoroso.cl</h2>
+        <h2 data-i18n="footer.site">nicolasmoroso.cl</h2>
       </div>
       <div class="footer-section">
-        <h3>Contacto:</h3>
+        <h3 data-i18n="footer.contactTitle">Contacto:</h3>
         <p>
           <img src="../mailto.png" alt="Correo" class="contact-icon mail-icon">
           <a href="mailto:info@nicolasmoroso.cl">info@nicolasmoroso.cl</a>
@@ -189,6 +197,7 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
     <img src="../ws.png" alt="WhatsApp">
   </a>
   <div class="overlay"></div>
+  <script src="../js/i18n.js"></script>
   <script src="../header.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="blog.js"></script>

--- a/educacion.html
+++ b/educacion.html
@@ -32,7 +32,7 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
 
   <meta name="google-site-verification" content="6CyGdduy_6elptw7WOq3KNZLswDURqGI__AuQbK5Fl8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Inicio</title>
+  <title data-i18n="education.meta.title">Educación</title>
 
   <link rel="icon" href="favicon.png" type="image/png">
   <link rel="stylesheet" href="desk.css">
@@ -62,7 +62,7 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
     <div class="header-logo">
      <a href="index.html" class="logo">
         <img src="logo.png" alt="Terapia Financiera" />
-        <span class="logo-text">
+        <span class="logo-text" data-i18n-html="nav.home">
         inicio<span class="orange-f"></span>
         </span>
       </a>
@@ -75,48 +75,56 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
     <nav class="header-nav">
       <ul>
         <li>
-          <a href="educacion.html" class="nav-item"><span class="orange-f">Educación</span></a>
+          <a href="educacion.html" class="nav-item"><span class="orange-f" data-i18n="nav.education">Educación</span></a>
         </li>
     
         <li class="simulador-dropdown">
-          <a href="#simulador" class="nav-item">Simulador</a>
+          <a href="#simulador" class="nav-item" data-i18n="nav.simulator">Simulador</a>
           <ul class="simulador-menu">
-            <li><a href="simulador.html" class="submenu-item">Créditos</a></li>
-            <li><a href="inversiones.html" class="submenu-item">Inversiones</a></li>
+            <li><a href="simulador.html" class="submenu-item" data-i18n="nav.simulatorCredits">Créditos</a></li>
+            <li><a href="inversiones.html" class="submenu-item" data-i18n="nav.simulatorInvestments">Inversiones</a></li>
           </ul>
         </li>
 
-        <li><a href="blog/index.html" class="nav-item">Blog</a></li>
+        <li><a href="blog/index.html" class="nav-item" data-i18n="nav.blog">Blog</a></li>
 
-        <li><a href="index.html#about" class="nav-item">Sobre Mí</a></li>
+        <li><a href="index.html#about" class="nav-item" data-i18n="nav.about">Sobre Mí</a></li>
       </ul>
     </nav>
     
     <!-- Botón de Agendar Reunión -->
 
-    <div class="header-agendar">
-      <a href="https://encuadrado.com/p/nicolas-moroso-1/" class="header-button desk-btn">AGENDAR</a>
-      <a href="https://encuadrado.com/p/nicolas-moroso-1/" class="header-button mobile-btn">AGENDAR</a>
+    <div class="header-actions">
+      <div class="header-agendar">
+        <a href="https://encuadrado.com/p/nicolas-moroso-1/" class="header-button desk-btn" data-i18n="nav.schedule">AGENDAR</a>
+        <a href="https://encuadrado.com/p/nicolas-moroso-1/" class="header-button mobile-btn" data-i18n="nav.schedule">AGENDAR</a>
+      </div>
+
+      <div class="language-toggle" aria-label="Selector de idioma">
+        <button type="button" class="language-toggle-button" data-lang="es">ES</button>
+        <span class="language-toggle-separator">|</span>
+        <button type="button" class="language-toggle-button" data-lang="en">EN</button>
+      </div>
     </div>
   
   <!-- Menú desplegable en móvil -->
   <div class="mobile-menu">
     <ul>
       <li>
-        <a href="educacion.html"><span class="orange-f">Educación</span></a>
+        <a href="educacion.html"><span class="orange-f" data-i18n="nav.education">Educación</span></a>
       </li>
   
       <li class="simulador-dropdown">
-        <a>Simulador</a>
+        <a data-i18n="nav.simulator">Simulador</a>
         <ul class="simulador-menu">
-          <li><a href="simulador.html" class="submenu-item">Créditos</a></li>
-          <li><a href="inversiones.html" class="submenu-item">Inversiones</a></li>
+          <li><a href="simulador.html" class="submenu-item" data-i18n="nav.simulatorCredits">Créditos</a></li>
+          <li><a href="inversiones.html" class="submenu-item" data-i18n="nav.simulatorInvestments">Inversiones</a></li>
         </ul>
       </li>
 
-      <li><a href="blog/index.html">Blog</a></li>
+      <li><a href="blog/index.html" data-i18n="nav.blog">Blog</a></li>
 
-      <li><a href="index.html#about">Sobre Mí</a></li>
+      <li><a href="index.html#about" data-i18n="nav.about">Sobre Mí</a></li>
 
     </ul>
   </div>
@@ -124,16 +132,16 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
 
   <!-- 🔽 AQUÍ VA EL CONTENIDO EXCLUSIVO DE LA PÁGINA educación.html -->
  <main class="container" style="padding: 120px 20px 60px 20px;">
-  <h1 style="text-align:center;">Repositorio de Educación Financiera</h1>
-  <p style="text-align:center; max-width: 700px; margin: 0 auto 40px;">
+  <h1 style="text-align:center;" data-i18n="education.title">Repositorio de Educación Financiera</h1>
+  <p style="text-align:center; max-width: 700px; margin: 0 auto 40px;" data-i18n-html="education.subtitle">
     <br><br>Aquí encontrarás recursos gratuitos y prácticos para mejorar tu relación con el dinero. Descarga, comparte y aprende a tu ritmo.
   </p>
 
     <div class="education-box">
       <div class="education-tabs">
-        <button data-tab="recursos">Recursos</button>
-        <button data-tab="bancos">Aprende de Bancos</button>
-        <button data-tab="finanzas">Aprende de Finanzas</button>
+        <button data-tab="recursos" data-i18n="education.tabs.resources">Recursos</button>
+        <button data-tab="bancos" data-i18n="education.tabs.banks">Aprende de Bancos</button>
+        <button data-tab="finanzas" data-i18n="education.tabs.finance">Aprende de Finanzas</button>
       </div>
       <div id="section-selectors" style="display:none; margin:20px 0;"></div>
       <div id="education-content"></div>
@@ -147,12 +155,12 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
       <div class="footer-container">
         <!-- Logo Footer -->
         <div class="footer-logo">
-          <h2>nicolasmoroso.cl</h2>
+          <h2 data-i18n="footer.site">nicolasmoroso.cl</h2>
         </div>
         
     <!-- Sección de Contacto -->
     <div class="footer-section">
-      <h3>Contacto:</h3>
+      <h3 data-i18n="footer.contactTitle">Contacto:</h3>
       <p>
         <img src="mailto.png" alt="Correo" class="contact-icon mail-icon">
         <a href="mailto:info@nicolasmoroso.cl">info@nicolasmoroso.cl</a>
@@ -183,6 +191,7 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
 
 
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script src="js/i18n.js"></script>
   <script src="educacion.js"></script>
   <script src="header.js"></script>
 </body>

--- a/educacion.js
+++ b/educacion.js
@@ -1,4 +1,11 @@
 let allItems = [];
+const getTranslation = (key, fallback) => {
+  if (window.t) {
+    const translated = window.t(key);
+    return translated === key ? fallback : translated;
+  }
+  return fallback;
+};
 
 document.addEventListener('DOMContentLoaded', () => {
   // 1) Carga la tabla completa desde Notion
@@ -89,8 +96,9 @@ function loadResources() {
     })
     .catch(err => {
       console.error('Error cargando recursos:', err);
+      const errorMessage = getTranslation('education.errors.resources', 'Error al cargar recursos.');
       document.getElementById('education-content').innerHTML =
-        '<p>Error al cargar recursos.</p>';
+        `<p>${errorMessage}</p>`;
     });
 }
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -146,6 +146,170 @@
       "error": "❌ An error occurred. Please try again later."
     }
   },
+  "education": {
+    "meta": {
+      "title": "Education"
+    },
+    "title": "Financial Education Repository",
+    "subtitle": "<br><br>Here you will find free, practical resources to improve your relationship with money. Download, share, and learn at your own pace.",
+    "tabs": {
+      "resources": "Resources",
+      "banks": "Learn from Banks",
+      "finance": "Learn about Finance"
+    },
+    "errors": {
+      "resources": "Error loading resources."
+    }
+  },
+  "simulator": {
+    "meta": {
+      "title": "Simulator"
+    },
+    "selector": {
+      "label": "Select the loan type:",
+      "options": {
+        "consumption": "Consumer Loan",
+        "mortgage": "Mortgage Loan",
+        "bullet": "Bullet Loan"
+      }
+    },
+    "consumption": {
+      "currencyLabel": "Currency to display results:",
+      "currencyPeso": "Chilean Peso ($)",
+      "currencyUf": "UF",
+      "loanAmountLabel": "Loan amount:",
+      "rateLabel": "Monthly interest rate (%):",
+      "installmentsLabel": "Installments:",
+      "graceLabel": "Grace months:",
+      "insuranceLabel": "Include credit life insurance",
+      "calculate": "Calculate",
+      "clear": "Clear",
+      "infoTitle": "Loan Information",
+      "info": {
+        "cae": "APR:",
+        "totalCredit": "Total credit cost:",
+        "totalInterest": "Total interest:",
+        "insurance": "Credit life insurance cost:",
+        "taxes": "Stamp duty cost:",
+        "installment": "Installment amount:",
+        "term": "Total loan term:"
+      }
+    },
+    "mortgage": {
+      "rateLabel": "Annual rate (%):",
+      "termLabel": "Number of periods (months):",
+      "graceLabel": "Number of grace periods (months):",
+      "propertyValueLabel": "Property value (UF):",
+      "financingLabel": "Financing percentage (%):",
+      "calculate": "Calculate",
+      "clear": "Clear",
+      "infoTitle": "Loan Information",
+      "info": {
+        "amount": "Amount to finance:",
+        "netInstallment": "Net installment:",
+        "insuranceLife": "Credit life insurance:",
+        "insuranceFire": "Fire insurance:",
+        "totalInstallment": "Total installment:",
+        "cae": "APR:",
+        "totalCredit": "Total credit cost:",
+        "totalInterest": "Total interest:",
+        "term": "Total term:"
+      }
+    },
+    "bullet": {
+      "currencyLabel": "Currency:",
+      "currencyPeso": "Chilean Peso ($)",
+      "currencyUf": "UF",
+      "rateLabel": "Interest rate (%):",
+      "amountLabel": "Principal amount:",
+      "termLabel": "Term (days):",
+      "insuranceLabel": "Include credit life insurance",
+      "calculate": "Calculate",
+      "clear": "Clear",
+      "infoTitle": "Loan Information",
+      "info": {
+        "totalCredit": "Total credit cost:",
+        "totalInterest": "Total interest:",
+        "insurance": "Credit life insurance cost:",
+        "cae": "APR:"
+      }
+    },
+    "table": {
+      "view": "View loan breakdown",
+      "close": "✕ Close"
+    },
+    "alerts": {
+      "invalidGrace": "Check the term and grace values.",
+      "invalidGraceMortgage": "Check the term and/or grace values.",
+      "invalidAmount": "Enter a valid amount.",
+      "invalidTerm": "Enter a valid term in days.",
+      "invalidRate": "Enter a valid interest rate."
+    },
+    "months": "months"
+  },
+  "investments": {
+    "meta": {
+      "title": "Investments"
+    },
+    "title": "Investment Simulator",
+    "frequencyLabel": "Time Unit",
+    "frequencyMonthly": "Monthly",
+    "frequencyAnnual": "Annual",
+    "termLabel": "Term",
+    "termPlaceholder": "e.g.: 30",
+    "rateLabel": "Rate (%)",
+    "ratePlaceholder": "e.g.: 1%",
+    "initialAmountLabel": "Initial savings amount",
+    "initialAmountPlaceholder": "e.g.: $1,000,000",
+    "monthlyAmountLabel": "Monthly savings amount",
+    "monthlyAmountPlaceholder": "e.g.: $200,000",
+    "calculate": "Calculate",
+    "clear": "Clear",
+    "referenceToggle": "Reference Rates",
+    "referenceClose": "✕ Close",
+    "referenceTitle": "Reference rate table (<span class=\"orange-f\">Monthly</span>/Annual)",
+    "table": {
+      "term": "Term",
+      "conservative": "Conservative",
+      "moderate": "Moderate",
+      "aggressive": "Aggressive",
+      "shortTerm": "Short<br>(0-1 year)",
+      "mediumTerm": "Medium<br>(1-3 years)",
+      "longTerm": "Long<br>(3+ years)",
+      "shortConservative": "Time deposit or liquidity fund (Money Market)",
+      "shortModerate": "Simple mixed fund (fixed income + equities)",
+      "shortAggressive": "Volatile sector ETF or short-term stocks",
+      "mediumConservative": "Local fixed-income fund or renewable deposit",
+      "mediumModerate": "Balanced fund with stocks and bonds",
+      "mediumAggressive": "Emerging markets ETF",
+      "longConservative": "Government bonds or international fixed-income fund",
+      "longModerate": "Diversified global ETF (e.g., ACWI)",
+      "longAggressive": "S&P 500 ETF or tech stock fund"
+    },
+    "referenceNote": "<br><strong>Source:</strong> Central Bank of Chile (BCP 1-year rate: 4.9%) + estimated premiums by risk profile.<br><strong>Important:</strong> These are illustrative examples and do not constitute investment advice.<br><strong>Note:</strong> The rates shown are <u>monthly/annual</u> and represent <u>nominal</u> returns (they do not account for inflation).",
+    "results": {
+      "estimatedValue": "Estimated value at the end of the term:"
+    },
+    "labels": {
+      "month": "Month",
+      "year": "Year"
+    },
+    "chart": {
+      "capital": "Invested Capital",
+      "interest": "Interest Earned",
+      "total": "Total Balance",
+      "axisMonths": "Months",
+      "axisYears": "Years",
+      "axisValue": "Value (MM$)",
+      "suffix": "MM$"
+    }
+  },
+  "blog": {
+    "meta": {
+      "title": "Blog"
+    },
+    "postImageAlt": "Post image"
+  },
   "footer": {
     "site": "nicolasmoroso.cl",
     "contactTitle": "Contact:"

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -146,6 +146,170 @@
       "error": "❌ Ocurrió un error. Intenta más tarde."
     }
   },
+  "education": {
+    "meta": {
+      "title": "Educación"
+    },
+    "title": "Repositorio de Educación Financiera",
+    "subtitle": "<br><br>Aquí encontrarás recursos gratuitos y prácticos para mejorar tu relación con el dinero. Descarga, comparte y aprende a tu ritmo.",
+    "tabs": {
+      "resources": "Recursos",
+      "banks": "Aprende de Bancos",
+      "finance": "Aprende de Finanzas"
+    },
+    "errors": {
+      "resources": "Error al cargar recursos."
+    }
+  },
+  "simulator": {
+    "meta": {
+      "title": "Simulador"
+    },
+    "selector": {
+      "label": "Selecciona el tipo de crédito:",
+      "options": {
+        "consumption": "Crédito de Consumo",
+        "mortgage": "Crédito Hipotecario",
+        "bullet": "Crédito Bullet"
+      }
+    },
+    "consumption": {
+      "currencyLabel": "Moneda para mostrar resultados:",
+      "currencyPeso": "Peso Chileno ($)",
+      "currencyUf": "UF",
+      "loanAmountLabel": "Monto del crédito:",
+      "rateLabel": "Tasa de interés mensual (%):",
+      "installmentsLabel": "Cuotas de pago:",
+      "graceLabel": "Meses de gracia:",
+      "insuranceLabel": "Incluir seguro de desgravamen",
+      "calculate": "Calcular",
+      "clear": "Limpiar",
+      "infoTitle": "Información del Crédito",
+      "info": {
+        "cae": "CAE:",
+        "totalCredit": "Costo total del crédito:",
+        "totalInterest": "Total intereses:",
+        "insurance": "Costo seguro de desgravamen:",
+        "taxes": "Costo timbres y estampillas:",
+        "installment": "Valor de la cuota:",
+        "term": "Plazo total del crédito:"
+      }
+    },
+    "mortgage": {
+      "rateLabel": "Tasa anual (%):",
+      "termLabel": "N° periodos (meses):",
+      "graceLabel": "N° periodos de gracia (meses):",
+      "propertyValueLabel": "Valor de la propiedad (UF):",
+      "financingLabel": "Porcentaje financiamiento (%):",
+      "calculate": "Calcular",
+      "clear": "Limpiar",
+      "infoTitle": "Información del Crédito",
+      "info": {
+        "amount": "Monto a financiar:",
+        "netInstallment": "Cuota Neta:",
+        "insuranceLife": "Seguro desgravamen:",
+        "insuranceFire": "Seguro incendio:",
+        "totalInstallment": "Cuota Total:",
+        "cae": "CAE:",
+        "totalCredit": "Costo total del crédito:",
+        "totalInterest": "Total intereses:",
+        "term": "Plazo total:"
+      }
+    },
+    "bullet": {
+      "currencyLabel": "Moneda:",
+      "currencyPeso": "Peso Chileno ($)",
+      "currencyUf": "UF",
+      "rateLabel": "Tasa de interés (%):",
+      "amountLabel": "Monto del capital:",
+      "termLabel": "Plazo (días):",
+      "insuranceLabel": "Incluir seguro de desgravamen",
+      "calculate": "Calcular",
+      "clear": "Limpiar",
+      "infoTitle": "Información del Crédito",
+      "info": {
+        "totalCredit": "Costo total del crédito:",
+        "totalInterest": "Total intereses:",
+        "insurance": "Costo seguro de desgravamen:",
+        "cae": "CAE:"
+      }
+    },
+    "table": {
+      "view": "Ver desarrollo del crédito",
+      "close": "✕ Cerrar"
+    },
+    "alerts": {
+      "invalidGrace": "Revisa los valores de plazo y gracia.",
+      "invalidGraceMortgage": "Revisa los valores de plazo y/o gracia.",
+      "invalidAmount": "Ingrese un monto válido.",
+      "invalidTerm": "Ingrese un plazo en días válido.",
+      "invalidRate": "Ingrese una tasa de interés válida."
+    },
+    "months": "meses"
+  },
+  "investments": {
+    "meta": {
+      "title": "Inversiones"
+    },
+    "title": "Simulador de Inversión",
+    "frequencyLabel": "Unidad de Tiempo",
+    "frequencyMonthly": "Mensual",
+    "frequencyAnnual": "Anual",
+    "termLabel": "Plazo",
+    "termPlaceholder": "Ej: 30",
+    "rateLabel": "Tasa (%)",
+    "ratePlaceholder": "Ej: 1%",
+    "initialAmountLabel": "Monto inicial de ahorro",
+    "initialAmountPlaceholder": "Ej: $1.000.000",
+    "monthlyAmountLabel": "Monto de ahorro mensual",
+    "monthlyAmountPlaceholder": "Ej: $200.000",
+    "calculate": "Calcular",
+    "clear": "Limpiar",
+    "referenceToggle": "Tasas Referenciales",
+    "referenceClose": "✕ Cerrar",
+    "referenceTitle": "Tabla referencial de tasas (<span class=\"orange-f\">Mensual</span>/Anual)",
+    "table": {
+      "term": "Plazo",
+      "conservative": "Conservador",
+      "moderate": "Moderado",
+      "aggressive": "Arriesgado",
+      "shortTerm": "Corto<br>(0-1 año)",
+      "mediumTerm": "Mediano<br>(1-3 años)",
+      "longTerm": "Largo<br>(3+ años)",
+      "shortConservative": "Depósito a plazo o fondo de liquidez (MoneyMarket)",
+      "shortModerate": "Fondo mixto simple (renta fija + variable)",
+      "shortAggressive": "ETF sectorial volátil o acciones de corto plazo",
+      "mediumConservative": "Fondo de renta fija nacional o depósito renovable",
+      "mediumModerate": "Fondo balanceado con acciones y bonos",
+      "mediumAggressive": "ETF de mercados emergentes",
+      "longConservative": "Bonos del gobierno o fondo internacional de renta fija",
+      "longModerate": "ETF global diversificado (ej: ACWI)",
+      "longAggressive": "ETF del S&P 500 o fondo de acciones tecnológicas"
+    },
+    "referenceNote": "<br><strong>Fuente:</strong> Banco Central de Chile (Tasa BCP 1 año: 4,9%) + primas estimadas según perfil de riesgo.<br><strong>Importante:</strong> Estos son ejemplos ilustrativos y no constituyen recomendación de inversión.<br><strong>Nota:</strong> Las tasas mostradas son <u>mensuales/anuales</u> y representan rentabilidades <u>nominales</u> (no consideran inflación).",
+    "results": {
+      "estimatedValue": "Valor estimado al final del plazo:"
+    },
+    "labels": {
+      "month": "Mes",
+      "year": "Año"
+    },
+    "chart": {
+      "capital": "Capital Invertido",
+      "interest": "Intereses Generados",
+      "total": "Total Patrimonio",
+      "axisMonths": "Meses",
+      "axisYears": "Años",
+      "axisValue": "Valor (MM$)",
+      "suffix": "MM$"
+    }
+  },
+  "blog": {
+    "meta": {
+      "title": "Blog"
+    },
+    "postImageAlt": "Imagen del post"
+  },
   "footer": {
     "site": "nicolasmoroso.cl",
     "contactTitle": "Contacto:"

--- a/inversiones.html
+++ b/inversiones.html
@@ -32,7 +32,7 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
 
   <meta name="google-site-verification" content="6CyGdduy_6elptw7WOq3KNZLswDURqGI__AuQbK5Fl8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Inicio</title>
+  <title data-i18n="investments.meta.title">Inversiones</title>
 
   <link rel="icon" href="favicon.png" type="image/png">
   <link rel="stylesheet" href="desk.css">
@@ -57,7 +57,7 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
     <div class="header-logo">
      <a href="index.html" class="logo">
         <img src="logo.png" alt="Terapia Financiera" />
-        <span class="logo-text">
+        <span class="logo-text" data-i18n-html="nav.home">
         inicio<span class="orange-f"></span>
         </span>
       </a>
@@ -70,48 +70,56 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
     <nav class="header-nav">
       <ul>
         <li>
-          <a href="educacion.html" class="nav-item">Educación</a>
+          <a href="educacion.html" class="nav-item" data-i18n="nav.education">Educación</a>
         </li>
     
         <li class="simulador-dropdown">
-          <a href="#simulador" class="nav-item"><span class="orange-f">Simulador</span></a>
+          <a href="#simulador" class="nav-item"><span class="orange-f" data-i18n="nav.simulator">Simulador</span></a>
           <ul class="simulador-menu">
-            <li><a href="simulador.html" class="submenu-item">Créditos</a></li>
-            <li><a href="inversiones.html" class="submenu-item">Inversiones</a></li>
+            <li><a href="simulador.html" class="submenu-item" data-i18n="nav.simulatorCredits">Créditos</a></li>
+            <li><a href="inversiones.html" class="submenu-item" data-i18n="nav.simulatorInvestments">Inversiones</a></li>
           </ul>
         </li>
 
-        <li><a href="blog/index.html" class="nav-item">Blog</a></li>
+        <li><a href="blog/index.html" class="nav-item" data-i18n="nav.blog">Blog</a></li>
 
-        <li><a href="index.html#about" class="nav-item">Sobre Mí</a></li>
+        <li><a href="index.html#about" class="nav-item" data-i18n="nav.about">Sobre Mí</a></li>
       </ul>
     </nav>
     
     <!-- Botón de Agendar Reunión -->
 
-    <div class="header-agendar">
-      <a href="https://encuadrado.com/p/nicolas-moroso-1/" class="header-button desk-btn">AGENDAR</a>
-      <a href="https://encuadrado.com/p/nicolas-moroso-1/" class="header-button mobile-btn">AGENDAR</a>
+    <div class="header-actions">
+      <div class="header-agendar">
+        <a href="https://encuadrado.com/p/nicolas-moroso-1/" class="header-button desk-btn" data-i18n="nav.schedule">AGENDAR</a>
+        <a href="https://encuadrado.com/p/nicolas-moroso-1/" class="header-button mobile-btn" data-i18n="nav.schedule">AGENDAR</a>
+      </div>
+
+      <div class="language-toggle" aria-label="Selector de idioma">
+        <button type="button" class="language-toggle-button" data-lang="es">ES</button>
+        <span class="language-toggle-separator">|</span>
+        <button type="button" class="language-toggle-button" data-lang="en">EN</button>
+      </div>
     </div>
   
   <!-- Menú desplegable en móvil -->
   <div class="mobile-menu">
     <ul>
       <li>
-        <a href="educacion.html">Educación</a>
+        <a href="educacion.html" data-i18n="nav.education">Educación</a>
       </li>
   
       <li class="simulador-dropdown">
-        <a><span class="orange-f">Simulador</span></a>
+        <a><span class="orange-f" data-i18n="nav.simulator">Simulador</span></a>
         <ul class="simulador-menu">
-          <li><a href="simulador.html" class="submenu-item">Créditos</a></li>
-          <li><a href="inversiones.html" class="submenu-item">Inversiones</a></li>
+          <li><a href="simulador.html" class="submenu-item" data-i18n="nav.simulatorCredits">Créditos</a></li>
+          <li><a href="inversiones.html" class="submenu-item" data-i18n="nav.simulatorInvestments">Inversiones</a></li>
         </ul>
       </li>
 
-      <li><a href="blog/index.html">Blog</a></li>
+      <li><a href="blog/index.html" data-i18n="nav.blog">Blog</a></li>
 
-      <li><a href="index.html#about">Sobre Mí</a></li>
+      <li><a href="index.html#about" data-i18n="nav.about">Sobre Mí</a></li>
 
     </ul>
   </div>
@@ -125,39 +133,39 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
   <!-- Contenedor para el Simulador de Inversiones -->
   <div class="simulador-inversiones">
     <div class="formulario">
-      <h2>Simulador de Inversión</h2>
+      <h2 data-i18n="investments.title">Simulador de Inversión</h2>
       <!-- Cada par label/input se agrupa en form-group -->
       <div class="form-group">
-        <label for="frecuencia">Unidad de Tiempo</label>
+        <label for="frecuencia" data-i18n="investments.frequencyLabel">Unidad de Tiempo</label>
         <select id="frecuencia">
-          <option value="mensual">Mensual</option>
-          <option value="anual">Anual</option>
+          <option value="mensual" data-i18n="investments.frequencyMonthly">Mensual</option>
+          <option value="anual" data-i18n="investments.frequencyAnnual">Anual</option>
         </select>
       </div>
       
       <div class="form-group">
-        <label for="plazo">Plazo</label>
-        <input type="number" id="plazo" min="1" placeholder="Ej: 30" />
+        <label for="plazo" data-i18n="investments.termLabel">Plazo</label>
+        <input type="number" id="plazo" min="1" placeholder="Ej: 30" data-i18n-placeholder="investments.termPlaceholder" />
       </div>
       
       <div class="form-group">
-        <label for="tasa">Tasa (%)</label>
-        <input type="text" id="tasa" placeholder="Ej: 1%" onblur="formatPercentage(this)" onfocus="removePercentageFormatting(this)" />
+        <label for="tasa" data-i18n="investments.rateLabel">Tasa (%)</label>
+        <input type="text" id="tasa" placeholder="Ej: 1%" data-i18n-placeholder="investments.ratePlaceholder" onblur="formatPercentage(this)" onfocus="removePercentageFormatting(this)" />
       </div>
       
       <div class="form-group">
-        <label for="montoInicial">Monto inicial de ahorro</label>
-        <input type="text" id="montoInicial" placeholder="Ej: $1.000.000" onblur="formatMoney(this)" onfocus="removeFormatting(this)" />
+        <label for="montoInicial" data-i18n="investments.initialAmountLabel">Monto inicial de ahorro</label>
+        <input type="text" id="montoInicial" placeholder="Ej: $1.000.000" data-i18n-placeholder="investments.initialAmountPlaceholder" onblur="formatMoney(this)" onfocus="removeFormatting(this)" />
       </div>
       
       <div class="form-group">
-        <label for="montoMensual">Monto de ahorro mensual</label>
-        <input type="text" id="montoMensual" placeholder="Ej: $200.000" onblur="formatMoney(this)" onfocus="removeFormatting(this)" />
+        <label for="montoMensual" data-i18n="investments.monthlyAmountLabel">Monto de ahorro mensual</label>
+        <input type="text" id="montoMensual" placeholder="Ej: $200.000" data-i18n-placeholder="investments.monthlyAmountPlaceholder" onblur="formatMoney(this)" onfocus="removeFormatting(this)" />
       </div>
       
-      <button class="inversion-btn" onclick="calcularInversion()">Calcular</button>
-      <button class="inversion-clear-btn" onclick="limpiarSimulador()">Limpiar</button>
-      <button id="toggle-referencia" class="inversion-btn">Tasas Referenciales</button>
+      <button class="inversion-btn" onclick="calcularInversion()" data-i18n="investments.calculate">Calcular</button>
+      <button class="inversion-clear-btn" onclick="limpiarSimulador()" data-i18n="investments.clear">Limpiar</button>
+      <button id="toggle-referencia" class="inversion-btn" data-i18n="investments.referenceToggle">Tasas Referenciales</button>
       <div class="resultado" id="resultado"></div>
 
       <!-- Área para el gráfico -->
@@ -168,63 +176,63 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
 
 
   <div class="referencia-panel" id="referencia-panel">
-      <button id="close-referencia" class="inversion-clear-btn">✕ Cerrar</button>
+      <button id="close-referencia" class="inversion-clear-btn" data-i18n="investments.referenceClose">✕ Cerrar</button>
       
     <div class="referencia">
-      <h2>Tabla referencial de tasas (<span class="orange-f">Mensual</span>/Anual) </h2>
+      <h2 data-i18n-html="investments.referenceTitle">Tabla referencial de tasas (<span class="orange-f">Mensual</span>/Anual) </h2>
       <table>
         <thead>
           <tr>
-            <th>Plazo</th>
-            <th>Conservador</th>
-            <th>Moderado</th>
-            <th>Arriesgado</th>
+            <th data-i18n="investments.table.term">Plazo</th>
+            <th data-i18n="investments.table.conservative">Conservador</th>
+            <th data-i18n="investments.table.moderate">Moderado</th>
+            <th data-i18n="investments.table.aggressive">Arriesgado</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td>Corto<br>(0-1 año)</td>
+            <td data-i18n-html="investments.table.shortTerm">Corto<br>(0-1 año)</td>
             <td class="referencia-cell">
               <strong><span class="orange-f">0,44%</span> / 5,4%<br></strong>
-              Depósito a plazo o fondo de liquidez (MoneyMarket)
+              <span data-i18n="investments.table.shortConservative">Depósito a plazo o fondo de liquidez (MoneyMarket)</span>
             </td>
             <td class="referencia-cell">
               <strong><span class="orange-f">0,56%</span> / 6,9%<br></strong>
-              Fondo mixto simple (renta fija + variable)
+              <span data-i18n="investments.table.shortModerate">Fondo mixto simple (renta fija + variable)</span>
             </td>
             <td class="referencia-cell">
               <strong><span class="orange-f">0,71%</span> / 8,9%<br></strong>
-              ETF sectorial volátil o acciones de corto plazo
+              <span data-i18n="investments.table.shortAggressive">ETF sectorial volátil o acciones de corto plazo</span>
             </td>
           </tr>
           <tr>
-            <td>Mediano<br>(1-3 años)</td>
+            <td data-i18n-html="investments.table.mediumTerm">Mediano<br>(1-3 años)</td>
             <td class="referencia-cell">
               <strong><span class="orange-f">0,48%</span> / 5,9%<br></strong>
-              Fondo de renta fija nacional o depósito renovable
+              <span data-i18n="investments.table.mediumConservative">Fondo de renta fija nacional o depósito renovable</span>
             </td>
             <td class="referencia-cell">
               <strong><span class="orange-f">0,64%</span> / 7,9%<br></strong>
-              Fondo balanceado con acciones y bonos
+              <span data-i18n="investments.table.mediumModerate">Fondo balanceado con acciones y bonos</span>
             </td>
             <td class="referencia-cell">
               <strong><span class="orange-f">0,83%</span> / 10,4%<br></strong>
-              ETF de mercados emergentes
+              <span data-i18n="investments.table.mediumAggressive">ETF de mercados emergentes</span>
             </td>
           </tr>
           <tr>
-            <td>Largo<br>(3+ años)</td>
+            <td data-i18n-html="investments.table.longTerm">Largo<br>(3+ años)</td>
             <td class="referencia-cell">
               <strong><span class="orange-f">0,52%</span> / 6,4%<br></strong>
-              Bonos del gobierno o fondo internacional de renta fija
+              <span data-i18n="investments.table.longConservative">Bonos del gobierno o fondo internacional de renta fija</span>
             </td>
             <td class="referencia-cell">
               <strong><span class="orange-f">0,71%</span> / 8,9%<br></strong>
-              ETF global diversificado (ej: ACWI)
+              <span data-i18n="investments.table.longModerate">ETF global diversificado (ej: ACWI)</span>
             </td>
             <td class="referencia-cell">
               <strong><span class="orange-f">0,94%</span> / 11,9%<br></strong>
-              ETF del S&P 500 o fondo de acciones tecnológicas
+              <span data-i18n="investments.table.longAggressive">ETF del S&P 500 o fondo de acciones tecnológicas</span>
             </td>
           </tr>
         </tbody>
@@ -232,9 +240,9 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
       
       <p>
         <small>
-          <br><strong>Fuente:</strong> Banco Central de Chile (Tasa BCP 1 año: 4,9%) + primas estimadas según perfil de riesgo.<br>
+          <span data-i18n-html="investments.referenceNote"><br><strong>Fuente:</strong> Banco Central de Chile (Tasa BCP 1 año: 4,9%) + primas estimadas según perfil de riesgo.<br>
           <strong>Importante:</strong> Estos son ejemplos ilustrativos y no constituyen recomendación de inversión.<br>
-          <strong>Nota:</strong> Las tasas mostradas son <u>mensuales/anuales</u> y representan rentabilidades <u>nominales</u> (no consideran inflación).
+          <strong>Nota:</strong> Las tasas mostradas son <u>mensuales/anuales</u> y representan rentabilidades <u>nominales</u> (no consideran inflación).</span>
         </small>
       </p>
     </div>
@@ -246,12 +254,12 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
       <div class="footer-container">
         <!-- Logo Footer -->
         <div class="footer-logo">
-          <h2>nicolasmoroso.cl</h2>
+          <h2 data-i18n="footer.site">nicolasmoroso.cl</h2>
         </div>
         
     <!-- Sección de Contacto -->
     <div class="footer-section">
-      <h3>Contacto:</h3>
+      <h3 data-i18n="footer.contactTitle">Contacto:</h3>
       <p>
         <img src="mailto.png" alt="Correo" class="contact-icon mail-icon">
         <a href="mailto:info@nicolasmoroso.cl">info@nicolasmoroso.cl</a>
@@ -281,6 +289,7 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
   <div class="overlay"></div>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="js/i18n.js"></script>
   <script src="inversiones.js"></script>
   <script src="header.js"></script>
 </body>

--- a/inversiones.js
+++ b/inversiones.js
@@ -3,6 +3,13 @@
    ========================= */
 
    let chartInstance;
+   const getTranslation = (key, fallback) => {
+     if (window.t) {
+       const translated = window.t(key);
+       return translated === key ? fallback : translated;
+     }
+     return fallback;
+   };
 
    Chart.defaults.font.family = "'Montserrat', sans-serif";
    Chart.defaults.color = "#2E4057";
@@ -67,7 +74,7 @@
              ? montoMensual*i
              : montoMensual*((Math.pow(1+tm,i)-1)/tm)
            );
-         labels.push(`Mes ${i}`);
+         labels.push(`${getTranslation('investments.labels.month', 'Mes')} ${i}`);
          const capital = montoInicial + montoMensual*i;
          const interes = totalValue - capital;
          totalDataPoints.push(+totalValue.toFixed(0));
@@ -86,7 +93,7 @@
              ? montoMensual*12*i
              : montoMensual*12*((Math.pow(1+ta,i)-1)/ta)
            );
-         labels.push(`Año ${i}`);
+         labels.push(`${getTranslation('investments.labels.year', 'Año')} ${i}`);
          const capital = montoInicial + montoMensual*12*i;
          const interes = totalValue - capital;
          totalDataPoints.push(+totalValue.toFixed(0));
@@ -101,7 +108,7 @@
              ? montoMensual*12*n
              : montoMensual*12*((Math.pow(1+ta,n)-1)/ta)
            );
-         labels.push(`Año ${n.toFixed(1)}`);
+         labels.push(`${getTranslation('investments.labels.year', 'Año')} ${n.toFixed(1)}`);
          const capital = montoInicial + montoMensual*12*n;
          const interes = totalValue - capital;
          totalDataPoints.push(+totalValue.toFixed(0));
@@ -111,8 +118,9 @@
        }
      }
    
+     const estimatedLabel = getTranslation('investments.results.estimatedValue', 'Valor estimado al final del plazo:');
      document.getElementById('resultado').innerHTML =
-       `Valor estimado al final del plazo: <strong>$${Intl.NumberFormat('es-CL',{ maximumFractionDigits:0 }).format(inversionTotal)}</strong>`;
+       `${estimatedLabel} <strong>$${Intl.NumberFormat('es-CL',{ maximumFractionDigits:0 }).format(inversionTotal)}</strong>`;
    
      actualizarGrafico(labels, capitalDataPoints, interestDataPoints, totalDataPoints, frecuencia);
    }
@@ -124,9 +132,9 @@
        type: 'line',
        data: { labels,
          datasets: [
-           { label:'Capital Invertido', data:capitalDataPoints, borderColor:'blue', backgroundColor:'rgba(0,0,255,0.1)', fill:false, tension:0.2 },
-           { label:'Intereses Generados', data:interestDataPoints, borderColor:'green', backgroundColor:'rgba(0,255,0,0.1)', fill:false, tension:0.2 },
-           { label:'Total Patrimonio', data:totalDataPoints, borderColor:'#457B9D', backgroundColor:'rgba(69,123,157,0.1)', fill:false, tension:0.2 }
+           { label:getTranslation('investments.chart.capital', 'Capital Invertido'), data:capitalDataPoints, borderColor:'blue', backgroundColor:'rgba(0,0,255,0.1)', fill:false, tension:0.2 },
+           { label:getTranslation('investments.chart.interest', 'Intereses Generados'), data:interestDataPoints, borderColor:'green', backgroundColor:'rgba(0,255,0,0.1)', fill:false, tension:0.2 },
+           { label:getTranslation('investments.chart.total', 'Total Patrimonio'), data:totalDataPoints, borderColor:'#457B9D', backgroundColor:'rgba(69,123,157,0.1)', fill:false, tension:0.2 }
          ]
        },
        options: {
@@ -134,9 +142,11 @@
          maintainAspectRatio: false,
          plugins:{ legend:{ display:true, position:'top', labels:{boxWidth:20,boxHeight:20,padding:10} } },
          scales:{
-           x:{ title:{ display:true, text: frecuencia==='mensual'?'Meses':'Años' } },
-           y:{ title:{ display:true, text:'Valor (MM$)' },
-               ticks:{ callback:v=> (v/1e6).toLocaleString('es-CL',{minimumFractionDigits:1,maximumFractionDigits:1})+' MM$' }
+           x:{ title:{ display:true, text: frecuencia==='mensual'
+             ? getTranslation('investments.chart.axisMonths', 'Meses')
+             : getTranslation('investments.chart.axisYears', 'Años') } },
+           y:{ title:{ display:true, text:getTranslation('investments.chart.axisValue', 'Valor (MM$)') },
+               ticks:{ callback:v=> (v/1e6).toLocaleString('es-CL',{minimumFractionDigits:1,maximumFractionDigits:1})+` ${getTranslation('investments.chart.suffix', 'MM$')}` }
            }
          }
        }

--- a/simulador.html
+++ b/simulador.html
@@ -32,7 +32,7 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
 
   <meta name="google-site-verification" content="6CyGdduy_6elptw7WOq3KNZLswDURqGI__AuQbK5Fl8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Inicio</title>
+  <title data-i18n="simulator.meta.title">Simulador</title>
 
   <link rel="icon" href="favicon.png" type="image/png">
   <link rel="stylesheet" href="desk.css">
@@ -57,7 +57,7 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
     <div class="header-logo">
      <a href="index.html" class="logo">
         <img src="logo.png" alt="Terapia Financiera" />
-        <span class="logo-text">
+        <span class="logo-text" data-i18n-html="nav.home">
         inicio<span class="orange-f"></span>
         </span>
       </a>
@@ -70,48 +70,56 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
     <nav class="header-nav">
       <ul>
         <li>
-          <a href="educacion.html" class="nav-item">Educación</a>
+          <a href="educacion.html" class="nav-item" data-i18n="nav.education">Educación</a>
         </li>
     
         <li class="simulador-dropdown">
-          <a href="#simulador" class="nav-item"><span class="orange-f">Simulador</span></a>
+          <a href="#simulador" class="nav-item"><span class="orange-f" data-i18n="nav.simulator">Simulador</span></a>
           <ul class="simulador-menu">
-            <li><a href="simulador.html" class="submenu-item">Créditos</a></li>
-            <li><a href="inversiones.html" class="submenu-item">Inversiones</a></li>
+            <li><a href="simulador.html" class="submenu-item" data-i18n="nav.simulatorCredits">Créditos</a></li>
+            <li><a href="inversiones.html" class="submenu-item" data-i18n="nav.simulatorInvestments">Inversiones</a></li>
           </ul>
         </li>
 
-        <li><a href="blog/index.html" class="nav-item">Blog</a></li>
+        <li><a href="blog/index.html" class="nav-item" data-i18n="nav.blog">Blog</a></li>
 
-        <li><a href="index.html#about" class="nav-item">Sobre Mí</a></li>
+        <li><a href="index.html#about" class="nav-item" data-i18n="nav.about">Sobre Mí</a></li>
       </ul>
     </nav>
     
     <!-- Botón de Agendar Reunión -->
 
-    <div class="header-agendar">
-      <a href="https://encuadrado.com/p/nicolas-moroso-1/" class="header-button desk-btn">AGENDAR</a>
-      <a href="https://encuadrado.com/p/nicolas-moroso-1/" class="header-button mobile-btn">AGENDAR</a>
+    <div class="header-actions">
+      <div class="header-agendar">
+        <a href="https://encuadrado.com/p/nicolas-moroso-1/" class="header-button desk-btn" data-i18n="nav.schedule">AGENDAR</a>
+        <a href="https://encuadrado.com/p/nicolas-moroso-1/" class="header-button mobile-btn" data-i18n="nav.schedule">AGENDAR</a>
+      </div>
+
+      <div class="language-toggle" aria-label="Selector de idioma">
+        <button type="button" class="language-toggle-button" data-lang="es">ES</button>
+        <span class="language-toggle-separator">|</span>
+        <button type="button" class="language-toggle-button" data-lang="en">EN</button>
+      </div>
     </div>
   
   <!-- Menú desplegable en móvil -->
   <div class="mobile-menu">
     <ul>
       <li>
-        <a href="educacion.html">Educación</a>
+        <a href="educacion.html" data-i18n="nav.education">Educación</a>
       </li>
   
       <li class="simulador-dropdown">
-        <a><span class="orange-f">Simulador</span></a>
+        <a><span class="orange-f" data-i18n="nav.simulator">Simulador</span></a>
         <ul class="simulador-menu">
-          <li><a href="simulador.html" class="submenu-item">Créditos</a></li>
-          <li><a href="inversiones.html" class="submenu-item">Inversiones</a></li>
+          <li><a href="simulador.html" class="submenu-item" data-i18n="nav.simulatorCredits">Créditos</a></li>
+          <li><a href="inversiones.html" class="submenu-item" data-i18n="nav.simulatorInvestments">Inversiones</a></li>
         </ul>
       </li>
 
-      <li><a href="blog/index.html">Blog</a></li>
+      <li><a href="blog/index.html" data-i18n="nav.blog">Blog</a></li>
 
-      <li><a href="index.html#about">Sobre Mí</a></li>
+      <li><a href="index.html#about" data-i18n="nav.about">Sobre Mí</a></li>
 
     </ul>
   </div>
@@ -141,11 +149,11 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
 <!-- Sección para seleccionar el tipo de crédito -->
 <section class="selector-credito">
   <div class="form-group">
-    <label for="tipoCredito">Selecciona el tipo de crédito:</label>
+    <label for="tipoCredito" data-i18n="simulator.selector.label">Selecciona el tipo de crédito:</label>
     <select id="tipoCredito" onchange="mostrarSimulador()">
-      <option value="consumo">Crédito de Consumo</option>
-      <option value="hipotecario">Crédito Hipotecario</option>
-      <option value="bullet">Crédito Bullet</option>
+      <option value="consumo" data-i18n="simulator.selector.options.consumption">Crédito de Consumo</option>
+      <option value="hipotecario" data-i18n="simulator.selector.options.mortgage">Crédito Hipotecario</option>
+      <option value="bullet" data-i18n="simulator.selector.options.bullet">Crédito Bullet</option>
     </select>
   </div>
 </section>
@@ -160,81 +168,81 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
     <form id="simulador">
       <!-- Grupo para la selección de moneda -->
       <div class="form-group">
-        <label for="monedaSelect">Moneda para mostrar resultados:</label>
+        <label for="monedaSelect" data-i18n="simulator.consumption.currencyLabel">Moneda para mostrar resultados:</label>
         <select id="monedaSelect" name="monedaSelect">
-          <option value="peso" selected>Peso Chileno ($)</option>
-          <option value="uf">UF</option>
+          <option value="peso" selected data-i18n="simulator.consumption.currencyPeso">Peso Chileno ($)</option>
+          <option value="uf" data-i18n="simulator.consumption.currencyUf">UF</option>
         </select>
       </div>
 
       <!-- Grupo para el monto del crédito -->
       <div class="form-group">
-        <label for="monto">Monto del crédito:</label>
+        <label for="monto" data-i18n="simulator.consumption.loanAmountLabel">Monto del crédito:</label>
         <input type="text" id="monto" required>
       </div>
 
       <!-- Grupo para la tasa de interés -->
       <div class="form-group">
-        <label for="tasa">Tasa de interés mensual (%):</label>
+        <label for="tasa" data-i18n="simulator.consumption.rateLabel">Tasa de interés mensual (%):</label>
         <input type="number" id="tasa" step="0.01" required>
       </div>
 
       <!-- Grupo para las cuotas de pago -->
       <div class="form-group">
-        <label for="plazo">Cuotas de pago:</label>
+        <label for="plazo" data-i18n="simulator.consumption.installmentsLabel">Cuotas de pago:</label>
         <input type="number" id="plazo" required>
       </div>
 
       <!-- Grupo para los meses de gracia -->
       <div class="form-group">
-        <label for="gracia">Meses de gracia:</label>
+        <label for="gracia" data-i18n="simulator.consumption.graceLabel">Meses de gracia:</label>
         <input type="number" id="gracia" value="0" min="0">
       </div>
 
       <!-- Grupo para el checkbox del seguro -->
       <div class="form-group checkbox-group">
         <input type="checkbox" id="checkSeguro">
-        <label for="checkSeguro">Incluir seguro de desgravamen</label>
+        <label for="checkSeguro" data-i18n="simulator.consumption.insuranceLabel">Incluir seguro de desgravamen</label>
       </div>
 
       <!-- Grupo para los botones -->
       <div class="form-group button-group">
         <!-- Aquí se llama a cconsumoamort() -->
-        <button type="button" onclick="cconsumoamort()">Calcular</button>
-        <button type="button" onclick="limpiarSimulacion()">Limpiar</button>
+        <button type="button" onclick="cconsumoamort()" data-i18n="simulator.consumption.calculate">Calcular</button>
+        <button type="button" onclick="limpiarSimulacion()" data-i18n="simulator.consumption.clear">Limpiar</button>
       </div>
     </form>
   </div>
   
   <!-- Columna Derecha: Información del Crédito -->
   <div class="simulador-info">
-    <div class="info-title">Información del Crédito</div>
+    <div class="info-title" data-i18n="simulator.consumption.infoTitle">Información del Crédito</div>
     <div id="infoCAE" class="info-item">
-      <span class="info-label">CAE:</span>
+      <span class="info-label" data-i18n="simulator.consumption.info.cae">CAE:</span>
       <span class="info-value">--</span>
     </div>
     <div id="infoTotalCredito" class="info-item">
-      <span class="info-label">Costo total del crédito:</span>
+      <span class="info-label" data-i18n="simulator.consumption.info.totalCredit">Costo total del crédito:</span>
       <span class="info-value">--</span>
     </div>
     <div id="infoTotalIntereses" class="info-item">
-      <span class="info-label">Total intereses:</span>
+      <span class="info-label" data-i18n="simulator.consumption.info.totalInterest">Total intereses:</span>
       <span class="info-value">--</span>
     </div>
     <div id="infoSeguro" class="info-item">
-      <span class="info-label">Costo seguro de desgravamen:</span>
+      <span class="info-label" data-i18n="simulator.consumption.info.insurance">Costo seguro de desgravamen:</span>
       <span class="info-value">--</span>
     </div>
     <div id="infoTimbre" class="info-item">
-      <span class="info-label">Costo timbres y estampillas:</span>
+      <span class="info-label" data-i18n="simulator.consumption.info.taxes">Costo timbres y estampillas:</span>
       <span class="info-value">--</span>
     </div>
     <div id="infoCuota" class="info-item">
-      <span class="info-label">Valor de la cuota:</span>
+      <span class="info-label" data-i18n="simulator.consumption.info.installment">Valor de la cuota:</span>
       <span class="info-value">--</span>
     </div>
     <div id="infoPlazo" class="info-item">
-      <span class="info-label">Plazo total del crédito:</span>
+      <span class="info-label" data-i18n="simulator.consumption.info.term">Plazo total del crédito:</span>
       <span class="info-value">--</span>
     </div>
   </div>
@@ -247,80 +255,80 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
     <form id="formHipotecario">
       <!-- Tasa anual -->
       <div class="form-group">
-        <label for="tasaAnual">Tasa anual (%):</label>
+        <label for="tasaAnual" data-i18n="simulator.mortgage.rateLabel">Tasa anual (%):</label>
         <input type="number" id="tasaAnual" step="0.01" required>
       </div>
 
       <!-- Plazo (meses) -->
       <div class="form-group">
-        <label for="plazoHipotecario">N° periodos (meses):</label>
+        <label for="plazoHipotecario" data-i18n="simulator.mortgage.termLabel">N° periodos (meses):</label>
         <input type="number" id="plazoHipotecario" required>
       </div>
 
       <!-- Gracia -->
       <div class="form-group">
-        <label for="graciaHipotecario">N° periodos de gracia (meses):</label>
+        <label for="graciaHipotecario" data-i18n="simulator.mortgage.graceLabel">N° periodos de gracia (meses):</label>
         <input type="number" id="graciaHipotecario" value="0" min="0">
       </div>
 
       <!-- Valor propiedad -->
       <div class="form-group">
-        <label for="valorPropiedad">Valor de la propiedad (UF):</label>
+        <label for="valorPropiedad" data-i18n="simulator.mortgage.propertyValueLabel">Valor de la propiedad (UF):</label>
         <input type="text" id="valorPropiedad" required>
       </div>
 
       <!-- % financiamiento -->
       <div class="form-group">
-        <label for="financiamiento">Porcentaje financiamiento (%):</label>
+        <label for="financiamiento" data-i18n="simulator.mortgage.financingLabel">Porcentaje financiamiento (%):</label>
         <input type="number" id="financiamiento" required>
       </div>
 
       <!-- Botones -->
       <div class="form-group button-group">
         <!-- Aquí se llama a chipotecarioamort() -->
-        <button type="button" onclick="chipotecarioamort()">Calcular</button>
-        <button type="button" onclick="limpiarSimulacionHipotecario()">Limpiar</button>
+        <button type="button" onclick="chipotecarioamort()" data-i18n="simulator.mortgage.calculate">Calcular</button>
+        <button type="button" onclick="limpiarSimulacionHipotecario()" data-i18n="simulator.mortgage.clear">Limpiar</button>
       </div>
     </form>
   </div>
 
   <!-- Columna Derecha: Resultados -->
   <div class="simulador-info">
-      <div class="info-title">Información del Crédito</div>
+      <div class="info-title" data-i18n="simulator.mortgage.infoTitle">Información del Crédito</div>
       <div id="infoMontoFinanciar" class="info-item">
-        <span class="info-label">Monto a financiar:</span>
+        <span class="info-label" data-i18n="simulator.mortgage.info.amount">Monto a financiar:</span>
         <span class="info-value">--</span>
       </div>
       <div id="infoCuotaNeta" class="info-item">
-        <span class="info-label">Cuota Neta:</span>
+        <span class="info-label" data-i18n="simulator.mortgage.info.netInstallment">Cuota Neta:</span>
         <span class="info-value">--</span>
       </div>
       <div id="infoSeguroDesgravamen" class="info-item">
-        <span class="info-label">Seguro desgravamen:</span>
+        <span class="info-label" data-i18n="simulator.mortgage.info.insuranceLife">Seguro desgravamen:</span>
         <span class="info-value">--</span>
       </div>
       <div id="infoSeguroIncendio" class="info-item">
-        <span class="info-label">Seguro incendio:</span>
+        <span class="info-label" data-i18n="simulator.mortgage.info.insuranceFire">Seguro incendio:</span>
         <span class="info-value">--</span>
       </div>
       <div id="infoCuotaTotal" class="info-item">
-        <span class="info-label">Cuota Total:</span>
+        <span class="info-label" data-i18n="simulator.mortgage.info.totalInstallment">Cuota Total:</span>
         <span class="info-value">--</span>
       </div>
           <div id="infoCHIPCAE" class="info-item">
-      <span class="info-label">CAE:</span>
+      <span class="info-label" data-i18n="simulator.mortgage.info.cae">CAE:</span>
       <span class="info-value">--</span>
     </div>
     <div id="infoCHIPTotalCredito" class="info-item">
-      <span class="info-label">Costo total del crédito:</span>
+      <span class="info-label" data-i18n="simulator.mortgage.info.totalCredit">Costo total del crédito:</span>
       <span class="info-value">--</span>
     </div>
     <div id="infoCHIPTotalIntereses" class="info-item">
-      <span class="info-label">Total intereses:</span>
+      <span class="info-label" data-i18n="simulator.mortgage.info.totalInterest">Total intereses:</span>
       <span class="info-value">--</span>
     </div>
     <div id="infoCHIPPlazo" class="info-item">
-      <span class="info-label">Plazo total:</span>
+      <span class="info-label" data-i18n="simulator.mortgage.info.term">Plazo total:</span>
       <span class="info-value">--</span>
     </div>
     </div>
@@ -333,57 +341,57 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
     <form id="formBullet">
       <!-- Selección de moneda -->
       <div class="form-group">
-        <label for="monedaSelectBullet">Moneda:</label>
+        <label for="monedaSelectBullet" data-i18n="simulator.bullet.currencyLabel">Moneda:</label>
         <select id="monedaSelectBullet" name="monedaSelectBullet">
-          <option value="peso" selected>Peso Chileno ($)</option>
-          <option value="uf">UF</option>
+          <option value="peso" selected data-i18n="simulator.bullet.currencyPeso">Peso Chileno ($)</option>
+          <option value="uf" data-i18n="simulator.bullet.currencyUf">UF</option>
         </select>
       </div>
       <!-- Tasa de interés -->
       <div class="form-group">
-        <label for="tasaBullet">Tasa de interés (%):</label>
+        <label for="tasaBullet" data-i18n="simulator.bullet.rateLabel">Tasa de interés (%):</label>
         <input type="number" id="tasaBullet" step="0.01" required>
       </div>
       <!-- Monto del capital -->
       <div class="form-group">
-        <label for="montoBullet">Monto del capital:</label>
+        <label for="montoBullet" data-i18n="simulator.bullet.amountLabel">Monto del capital:</label>
         <input type="text" id="montoBullet" required>
       </div>
       <!-- Plazo en días -->
       <div class="form-group">
-        <label for="plazoDiasBullet">Plazo (días):</label>
+        <label for="plazoDiasBullet" data-i18n="simulator.bullet.termLabel">Plazo (días):</label>
         <input type="number" id="plazoDiasBullet" required>
       </div>
       <!-- Seguro de desgravamen -->
       <div class="form-group checkbox-group">
         <input type="checkbox" id="checkSeguroBullet">
-        <label for="checkSeguroBullet">Incluir seguro de desgravamen</label>
+        <label for="checkSeguroBullet" data-i18n="simulator.bullet.insuranceLabel">Incluir seguro de desgravamen</label>
       </div>
       <!-- Botones -->
       <div class="form-group button-group">
-        <button type="button" onclick="cbulletamort()">Calcular</button>
-        <button type="button" onclick="limpiarSimulacionBullet()">Limpiar</button>
+        <button type="button" onclick="cbulletamort()" data-i18n="simulator.bullet.calculate">Calcular</button>
+        <button type="button" onclick="limpiarSimulacionBullet()" data-i18n="simulator.bullet.clear">Limpiar</button>
       </div>
     </form>
   </div>
   
   <!-- Panel de Información del Crédito Bullet -->
   <div class="simulador-info">
-    <div class="info-title">Información del Crédito</div>
+    <div class="info-title" data-i18n="simulator.bullet.infoTitle">Información del Crédito</div>
     <div id="infoTotalCreditoBullet" class="info-item">
-      <span class="info-label">Costo total del crédito:</span>
+      <span class="info-label" data-i18n="simulator.bullet.info.totalCredit">Costo total del crédito:</span>
       <span class="info-value">--</span>
     </div>
     <div id="infoTotalInteresesBullet" class="info-item">
-      <span class="info-label">Total intereses:</span>
+      <span class="info-label" data-i18n="simulator.bullet.info.totalInterest">Total intereses:</span>
       <span class="info-value">--</span>
     </div>
     <div id="infoSeguroDesgravamenBullet" class="info-item">
-      <span class="info-label">Costo seguro de desgravamen:</span>
+      <span class="info-label" data-i18n="simulator.bullet.info.insurance">Costo seguro de desgravamen:</span>
       <span class="info-value">--</span>
     </div>
     <div id="infoCAE_Bullet" class="info-item">
-      <span class="info-label">CAE:</span>
+      <span class="info-label" data-i18n="simulator.bullet.info.cae">CAE:</span>
       <span class="info-value">--</span>
     </div>
   </div>
@@ -391,11 +399,11 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
 
 
 <!-- Botón para desplegar el cuadro de desarrollo -->
-<button id="toggleTabla" class="tabla-btn">Ver desarrollo del crédito</button>
+<button id="toggleTabla" class="tabla-btn" data-i18n="simulator.table.view">Ver desarrollo del crédito</button>
 
 <!-- Cuadro de desarrollo de pagos (tabla) -->
 <div id="tablaPanel">
-  <button id="closeTabla" class="tabla-close-btn">✕ Cerrar</button>
+  <button id="closeTabla" class="tabla-close-btn" data-i18n="simulator.table.close">✕ Cerrar</button>
   <div class="simulador-tabla" id="resultado"></div>
 </div>
 <div id="tablaOverlay" class="tabla-overlay"></div>
@@ -411,12 +419,12 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
     <div class="footer-container">
       <!-- Logo Footer -->
       <div class="footer-logo">
-        <h2>nicolasmoroso.cl</h2>
+        <h2 data-i18n="footer.site">nicolasmoroso.cl</h2>
       </div>
       
   <!-- Sección de Contacto -->
   <div class="footer-section">
-    <h3>Contacto:</h3>
+    <h3 data-i18n="footer.contactTitle">Contacto:</h3>
     <p>
       <img src="mailto.png" alt="Correo" class="contact-icon mail-icon">
       <a href="mailto:info@nicolasmoroso.cl">info@nicolasmoroso.cl</a>
@@ -445,6 +453,7 @@ src="https://www.facebook.com/tr?id=1460810141740139&ev=PageView&noscript=1"
   <!-- Elemento overlay -->
   <div class="overlay"></div>
 
+<script src="js/i18n.js"></script>
 <script src="simulador.js"></script>
 <script src="header.js"></script>
 </body>

--- a/simulador.js
+++ b/simulador.js
@@ -1,3 +1,11 @@
+const getTranslation = (key, fallback) => {
+  if (window.t) {
+    const translated = window.t(key);
+    return translated === key ? fallback : translated;
+  }
+  return fallback;
+};
+
 document.getElementById('tasa').addEventListener('blur', function(e) {
   let val = e.target.value.replace('%', '').trim();
   if (val) {
@@ -21,7 +29,7 @@ function cconsumoamort() {
   const monthsGrace = parseInt(document.getElementById('gracia').value) || 0;
   const totalMeses = monthsGrace + numPagos;
   if (numPagos <= 0 || monthsGrace < 0) {
-    alert("Revisa los valores de plazo y gracia.");
+    alert(getTranslation('simulator.alerts.invalidGrace', 'Revisa los valores de plazo y gracia.'));
     return;
   }
   const moneda = document.getElementById('monedaSelect').value;
@@ -109,7 +117,7 @@ function cconsumoamort() {
   document.querySelector('#infoSeguro .info-value').textContent = formatearMoneda(seguroTotal, moneda);
   document.querySelector('#infoTimbre .info-value').textContent = formatearMoneda(impuestoTotal, moneda);
   document.querySelector('#infoCuota .info-value').textContent = formatearMoneda(cuota, moneda);
-  document.querySelector('#infoPlazo .info-value').textContent = `${totalMeses} meses`;
+  document.querySelector('#infoPlazo .info-value').textContent = `${totalMeses} ${getTranslation('simulator.months', 'meses')}`;
 }
 
 // Función para calcular la TIR (IRR) usando búsqueda binaria
@@ -264,7 +272,7 @@ function chipotecarioamort() {
   const totalMeses = monthsGrace + numPagos;
   
   if (numPagos <= 0 || monthsGrace < 0) {
-    alert("Revisa los valores de plazo y/o gracia.");
+    alert(getTranslation('simulator.alerts.invalidGraceMortgage', 'Revisa los valores de plazo y/o gracia.'));
     return;
   }
   
@@ -414,7 +422,7 @@ function chipotecarioamort() {
   document.querySelector('#infoCHIPCAE .info-value').textContent = `${CAE.toFixed(2)}%`;
   document.querySelector('#infoCHIPTotalCredito .info-value').textContent = formatearUF(totalPagado.toFixed(2));
   document.querySelector('#infoCHIPTotalIntereses .info-value').textContent = formatearUF(totalIntereses.toFixed(2));
-  document.querySelector('#infoCHIPPlazo .info-value').textContent = `${totalMeses} meses`;
+  document.querySelector('#infoCHIPPlazo .info-value').textContent = `${totalMeses} ${getTranslation('simulator.months', 'meses')}`;
   
   // Además, se muestran los seguros "típicos" mensuales (sin acumulación) para referencia:
   const segDesgMensual = montoFinanciar * (porcentajeFinanciamiento / 100) * tasaSegDesg;
@@ -477,20 +485,20 @@ function cbulletamort() {
   let montoStr = document.getElementById('montoBullet').value.replace(/\./g, '');
   const monto = parseFloat(montoStr);
   if (isNaN(monto) || monto <= 0) {
-    alert("Ingrese un monto válido.");
+    alert(getTranslation('simulator.alerts.invalidAmount', 'Ingrese un monto válido.'));
     return;
   }
   
   const plazoDias = parseInt(document.getElementById('plazoDiasBullet').value);
   if (isNaN(plazoDias) || plazoDias <= 0) {
-    alert("Ingrese un plazo en días válido.");
+    alert(getTranslation('simulator.alerts.invalidTerm', 'Ingrese un plazo en días válido.'));
     return;
   }
   
   let tasaStr = document.getElementById('tasaBullet').value.replace(',', '.');
   const tasaInput = parseFloat(tasaStr);
   if (isNaN(tasaInput) || tasaInput <= 0) {
-    alert("Ingrese una tasa de interés válida.");
+    alert(getTranslation('simulator.alerts.invalidRate', 'Ingrese una tasa de interés válida.'));
     return;
   }
   
@@ -589,4 +597,3 @@ if (btnTabla && panelTabla && overlayTabla && btnCerrarTabla) {
   btnCerrarTabla.addEventListener('click', cerrarTabla);
   overlayTabla.addEventListener('click', cerrarTabla);
 }
-


### PR DESCRIPTION
### Motivation
- Apply the same language switchable UI already present on `index.html` to the other pages (`educacion.html`, `simulador.html`, `inversiones.html`, `blog/index.html`).
- Make static labels and dynamic UI text translatable so the language toggle (`window.t`) affects headers, controls and informational panels across pages.
- Provide translated strings for the newly localized elements in both Spanish and English JSON dictionaries.
- Ensure dynamically generated content (charts, error alerts, blog image alts) can show translations at runtime via the `languageChanged` event.

### Description
- Added `data-i18n`, `data-i18n-html`, and `data-i18n-placeholder` attributes and a language toggle UI to `educacion.html`, `simulador.html`, `inversiones.html`, and `blog/index.html`, and included the `js/i18n.js` loader where missing. 
- Extended translation files `i18n/es.json` and `i18n/en.json` with keys for education, simulator, investments and blog sections (meta, labels, buttons, alerts, chart texts, etc.).
- Instrumented scripts to use a small helper `getTranslation(key, fallback)` that reads from `window.t(...)`, and replaced hard-coded strings with translated values in `simulador.js`, `inversiones.js`, `educacion.js` and `blog/blog.js` (including chart labels, alerts, result text and blog image `alt`).
- Added a runtime update for blog image `alt` attributes and hooked it to `languageChanged` so dynamic content reflects the selected language.

### Testing
- Verified both `i18n/es.json` and `i18n/en.json` are valid JSON by loading them with Python's `json` module (succeeded).
- Launched a local static server (`python -m http.server`) and captured a Playwright screenshot of `educacion.html` to confirm the language toggle appears (succeeded, screenshot saved).
- Performed a commit after changes to ensure patching applied cleanly (commit created successfully).
- No unit tests were added; behavior of translations in interactive flows was exercised via the live page screenshot but not covered by automated unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69659290de4483228cc6612334fd830f)